### PR TITLE
Adds a medium search size for inline search

### DIFF
--- a/components/blocks/search/search.config.yml
+++ b/components/blocks/search/search.config.yml
@@ -6,6 +6,10 @@ variants:
     context:
       theme: sm
       show_label: false
+  - name: Medium
+    context:
+      theme: md 
+      show_label: false
   - name: Yellow
     context:
       theme: y

--- a/stylesheets/components/search/_full.styl
+++ b/stylesheets/components/search/_full.styl
@@ -83,6 +83,23 @@
     width: 18px
     margin-top: -2px
 
+  &--md &-i-f
+    font-size: responsive 20px 50px
+    font-range: 480px 1440px
+    border-bottom-width: $border-200
+
+    @media $media-medium
+      border-bottom-width: $border-400
+
+  &--md &-i-b
+    height: 20px
+    width: 20px
+    margin-top: -4px
+
+    @media $media-medium
+      height: 35px
+      width: 35px
+
   &--y &-i-f
     color: $charles-blue
 


### PR DESCRIPTION
Goal is to match this design: ![311 look up no result](https://cloud.githubusercontent.com/assets/20642299/24112068/c4954650-0d6e-11e7-9b4e-ffaab958c262.png)
