### PR TITLE
Adds --sticky option for secondary nav

### DIFF
--- a/stylesheets/components/header/_component.styl
+++ b/stylesheets/components/header/_component.styl
@@ -24,6 +24,7 @@
   width: 100%
   z-index: 3
   transition: left 0.2s
+  min-height: 65px
 
   .brg-b
     margin-right: $sizing-300

--- a/stylesheets/components/main/_main.styl
+++ b/stylesheets/components/main/_main.styl
@@ -17,6 +17,13 @@
   min-width: 100%
   min-height: 100%
 
-  &-c
+  // takes up the full page height (minus sticky header)
+  &--full
     min-height: 100vh
-    min-width: 100vw
+    display: flex
+    flex-direction: column
+    justify-content: center
+
+  // when secondary navigation is included
+  &--nv-s
+    padding-top: 119px

--- a/stylesheets/components/navigation/_secondary.styl
+++ b/stylesheets/components/navigation/_secondary.styl
@@ -7,6 +7,8 @@
 
  */
 .nv
+  box-shadow: 0 1px 2px 1px rgba(0,0,0,0.1)
+
   &-s
     line-height: $line-height-000
 
@@ -82,6 +84,14 @@
 
     &--c &-l
       justify-content: center
+
+    // Top position is here to line up with the height of header
+    &--sticky
+      position: fixed
+      z-index: 3
+      top: 65px
+      left: 0
+      right: 0
 
     // "y" theme only changes the color of the active link on desktop, not mobile
     &--y &-l-a--active


### PR DESCRIPTION
Also adds a variant for the "mn" element to take up the full screen
height (minus the sticky navs) with flexbox.

Also enforces 65px min-height for primary nav, as hiding its nav
elements on small screens was shrinking it to 63px.