### PR TITLE
Switches unordered list to use flexbox

### DIFF
--- a/components/blocks/list/list.config.yml
+++ b/components/blocks/list/list.config.yml
@@ -4,6 +4,10 @@ status: ready
 context:
   items:
     - content: Speed limit sign needed
+      class: t--intro
     - content: Excessive noise
+      class: t--info
     - content: Request a speedbump
-    - content: Request a traffic study
+      class: t--sans tt-u
+    - content: Request a<br/>traffic study
+      class: t--sans tt-u

--- a/components/blocks/list/list.hbs
+++ b/components/blocks/list/list.hbs
@@ -1,5 +1,5 @@
 <ul class="ul">
   {{#each items as |item|}}
-    <li><span class="t--sans t--upper"><a href="javascript:void(0)">{{ item.content }}</a></span></li>
+    <li class="{{ item.class }}"><a href="javascript:void(0)">{{{ item.content }}}</a></li>
   {{/each}}
 </ul>

--- a/stylesheets/base/global/_lists.styl
+++ b/stylesheets/base/global/_lists.styl
@@ -1,6 +1,6 @@
 .ul
   list-style: none
-  padding: 0 $sizing-500
+  padding: 0 0 0 $sizing-600
   margin: 0
 
   & > li
@@ -12,9 +12,11 @@
       border-color: transparent $charles-blue
       border-style: solid
       border-width: $border-400 0 $border-400 $border-500
-      display: block
-      position: relative
+      display: inline-block
       height: 0
       width: 0
-      left: -($sizing-400)
-      top: 1rem
+      vertical-align: middle
+      margin-left: -($border-500 + $sizing-200)
+      margin-right: $sizing-200
+      // compensates a bit for descenders to line us up centered with the text
+      margin-bottom: 0.25em


### PR DESCRIPTION
Old approach was leaving empty space on the top of each <li> due to the
arrow's original space (it was relatively positioned).