### PR TITLE
Adds responsive sizing to step header class

### DIFF
--- a/stylesheets/base/global/_text.styl
+++ b/stylesheets/base/global/_text.styl
@@ -16,6 +16,16 @@
     font-style: italic
     line-height: $line-height-300
 
+  // starts smaller than --info but has responsive font sizing so it doesn't
+  // end up bigger on mobile.
+  &--subinfo
+    color: $charles-blue
+    font-family: $serif
+    font-size: responsive 12px 16px
+    font-range: 480px 1440px
+    font-style: italic
+    line-height: $line-height-300
+
   &--subtitle
     color: $charles-blue
     font-family: $sans

--- a/stylesheets/components/step-header/_header.styl
+++ b/stylesheets/components/step-header/_header.styl
@@ -1,7 +1,8 @@
 .stp
   text-transform: uppercase
   font-family: $sans
-  font-size: $font-700
+  font-size: responsive 16px 20px
+  font-range: 480px 1440px
   color: $charles-blue
   display: flex
   align-items: center


### PR DESCRIPTION
Also adds a 'subinfo' class that starts at the default text size but
shrinks to 12px. Otherwise default-sized text is smaller than t--info on
desktop but larger than it on mobile.