### PR TITLE
Makes header z-index > 2ndary nav z-index

### DIFF
--- a/stylesheets/components/header/_component.styl
+++ b/stylesheets/components/header/_component.styl
@@ -22,7 +22,7 @@
   top: 0
   left: 0
   width: 100%
-  z-index: 3
+  z-index: 4
   transition: left 0.2s
   min-height: 65px
 


### PR DESCRIPTION
Makes the "search" drop-down overlap on top of the secondary nav rather
than going behind it.