### PR TITLE
Remove iPhone footer on desktop

### DIFF
--- a/stylesheets/components/main/_main.styl
+++ b/stylesheets/components/main/_main.styl
@@ -28,6 +28,9 @@
     flex-direction: column
     justify-content: flex-start
 
+    @media $media-large
+      min-height: 100vh
+
     // vertically-centered on larger screens
     &-vc
       @media $media-large


### PR DESCRIPTION
Removes the space set aside for the iPhone's nav buttons on media-large devices. Lets us do full-size fixed elements (like the 311 map) without worrying about the bottom bit sometimes being overlapped by the footer.