### PR TITLE
IE 9 nav / header fixes

### DIFF
--- a/stylesheets/components/navigation/_secondary.styl
+++ b/stylesheets/components/navigation/_secondary.styl
@@ -12,6 +12,7 @@
   &-s
     line-height: $line-height-000
     transition: left 0.2s
+    background-color: $charles-blue
 
     &-tr
       display: none
@@ -23,7 +24,6 @@
           transform: translateY(-52%) rotateZ(90deg)
 
     &-l
-      background-color: $charles-blue
       list-style: none
       margin: 0
       padding: 0

--- a/stylesheets/shame/grid/_grid.styl
+++ b/stylesheets/shame/grid/_grid.styl
@@ -20,8 +20,7 @@
   &--2
     lost-column: 12/12
 
-  &--3,
-  &--33
+  &--3
     lost-column: 12/12
 
   &--4
@@ -51,30 +50,36 @@
   &--12
     lost-column: 12/12
 
-  &--4
-    margin-top: $sizing-200
-
   @media $media-large
     &--1
-      lost-column: 1/12
+      lost-column: 1/12 12
+
+      &--sl
+        lost-column: 6/12 2
 
     &--2
-      lost-column: 2/12
+      lost-column: 2/12 6
+
+      &--sl
+        lost-column: 6/12 2
 
     &--3
-      lost-column: 6/12
+      lost-column: 3/12 4
+
+      &--sl
+        lost-column: 6/12 2
 
     &--4
-      lost-column: 1/2
+      lost-column: 4/12 3
 
-    &--44
-      lost-column: 4/12
+      &--sl
+        lost-column: 6/12 2
 
     &--5
       lost-column: 5/12
 
     &--6
-      lost-column: 6/12
+      lost-column: 6/12 2
 
     &--7
       lost-column: 7/12
@@ -94,12 +99,23 @@
     &--12
       lost-column: 12/12
 
-    &--4
-      margin-top: $sizing-400
-
   @media $media-xlarge
-    &--33
-      lost-column: 3/12
-      
+    &--1
+      &--sl
+        lost-column: 1/12 12
+        
+    &--2
+      &--sl
+        lost-column: 2/12 6
+        
+    &--3
+      &--sl
+        lost-column: 3/12 4
+        
     &--4
-      lost-column: 1/4
+      &--sl
+        lost-column: 4/12 3
+        
+    &--5
+      &--sl
+        lost-column: 5/12

--- a/stylesheets/shame/logo/_logo.styl
+++ b/stylesheets/shame/logo/_logo.styl
@@ -20,8 +20,9 @@
   &-i
     float: left
     position: relative
-    top: 9px
 
+    @media screen and (min-width: 1054px)
+      top: 7px 
 
   &-t
     float: left

--- a/stylesheets/shame/navigation/_header.styl
+++ b/stylesheets/shame/navigation/_header.styl
@@ -1,0 +1,31 @@
+/*
+
+   HEADER NAV
+
+   Base:
+    nv-h
+
+ */
+
+.brg-b
+  float: left
+
+.nv
+  &-h
+    float: right
+      
+    &-l
+      lost-utility: clearfix
+
+      &-i
+        float: left
+
+      &-a
+        &-ic
+          margin-top: 0
+
+          @media $media-large
+            margin-top: -4px
+
+          & > *
+            vertical-align: middle

--- a/stylesheets/shame/navigation/_secondary.styl
+++ b/stylesheets/shame/navigation/_secondary.styl
@@ -1,0 +1,11 @@
+.nv
+  &-s
+    lost-utility: clearfix
+
+    &-l
+      @media $media-large
+        float: right
+
+      &-a
+        @media $media-large
+          float: left

--- a/stylesheets/shame/navigation/base.styl
+++ b/stylesheets/shame/navigation/base.styl
@@ -1,0 +1,8 @@
+/*
+
+   NAVIGATION
+
+*/
+
+@require('*.styl')
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -837,7 +837,7 @@ css-parse@1.7.x:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/css-parse/-/css-parse-1.7.0.tgz#321f6cf73782a6ff751111390fc05e2c657d8c9b"
 
-cssnano@^3.10.0:
+cssnano@^3.0.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-3.10.0.tgz#4f38f6cea2b9b17fa01490f23f1dc68ea65c1c38"
   dependencies:
@@ -1602,6 +1602,15 @@ gulp-concat@^2.6.1:
     concat-with-sourcemaps "^1.0.0"
     through2 "^2.0.0"
     vinyl "^2.0.0"
+
+gulp-cssnano@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/gulp-cssnano/-/gulp-cssnano-2.1.2.tgz#e08a09771ec5454a549f1a005bdd256cb8e5e0a3"
+  dependencies:
+    cssnano "^3.0.0"
+    gulp-util "^3.0.6"
+    object-assign "^4.0.1"
+    vinyl-sourcemaps-apply "^0.2.1"
 
 gulp-load-plugins@^1.2.4:
   version "1.5.0"
@@ -4315,7 +4324,7 @@ vinyl-fs@^0.3.0:
     through2 "^0.6.1"
     vinyl "^0.4.0"
 
-vinyl-sourcemaps-apply@^0.2.0:
+vinyl-sourcemaps-apply@^0.2.0, vinyl-sourcemaps-apply@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz#ab6549d61d172c2b1b87be5c508d239c8ef87705"
   dependencies:


### PR DESCRIPTION
 - Updates the shame CSS to make primary and secondary headers look right

 - Updates the shame grid to match the latest semantics for the --n classes.

 - Also updates out-of-date yarn.lock.