### PR TITLE
Changes many border widths to pixels

### DIFF
--- a/stylesheets/components/form/_search.styl
+++ b/stylesheets/components/form/_search.styl
@@ -99,7 +99,7 @@
     border-bottom-width: $border-200
 
     @media $media-medium
-      border-bottom-width: $border-300
+      border-bottom-width: $border-250
 
   &--md &-i-b
     height: 20px

--- a/stylesheets/variables/_border-widths.styl
+++ b/stylesheets/variables/_border-widths.styl
@@ -1,7 +1,8 @@
 $border-000 = 0
-$border-100 = 0.05555555555rem // ~1px
-$border-150 = 0.16666666666rem // ~2px
-$border-200 = 0.22222222222rem // ~4px
-$border-300 = 0.33333333333rem // ~6px
+$border-100 = 1px
+$border-150 = 2px
+$border-200 = 3px
+$border-250 = 0.22222222222rem // ~3.5px
+$border-300 = 0.33333333333rem // ~5.3px
 $border-400 = 0.44444444444rem // ~8px
 $border-500 = 0.55555555555rem // ~10px


### PR DESCRIPTION
For small borders, we want to size exactly in pixels so that the
browser doesn't round in inconsistent ways.

For larger borders (typically header underlines) it's ok to stay
relative.

Also shrinks the border under the medium search box slightly.