### PR TITLE
Fixes square select for IE10

### DIFF
--- a/stylesheets/components/form/_select.styl
+++ b/stylesheets/components/form/_select.styl
@@ -73,12 +73,24 @@
       line-height: $line-height-200
 
     &--sq
-      text-indent: -9999px
-      width: 60px
-      padding-left: 0
-      padding-right: 0
+      // IE10 doesn't support the pointer-events property used to make the
+      // arrow "click through" to the select box. When all you can see is
+      // the arrow, this presents a problem, so we have to position the select
+      // above the arrow, then make it hidden so just its focus ring appears.
+      position: relative
       box-sizing: content-box
-
+      z-index: 2
+      width: 0
+      padding-left: 0
+      padding-right: 60px
+      overflow: hidden
+      text-indent: -9999px
+      background: transparent
+      
+      // hides the arrow box on IE10
+      &::-ms-expand
+        display: none
+        
     &--err
       border-color: $freedom-red
       color: $freedom-red


### PR DESCRIPTION
IE10 doesn't support the "pointer-events: none" for the arrow ":after"
element, which isn't a huge deal for the long select box but means
that the square select box is unusable.

For the square version, this positions an invisible select over the
arrow so that it still gets its clicks.