### PR TITLE
Makes drawer subtitle Monserrat by default

### DIFF
--- a/stylesheets/components/drawers/_drawer.styl
+++ b/stylesheets/components/drawers/_drawer.styl
@@ -120,9 +120,9 @@
 
   &-st
     color: $charles-blue
-    font-family: $sans
-    font-size: responsive 12px 16px
+    font-family: $serif
+    font-size: responsive 14px 18px
     font-range: 480px 1440px
     line-height: $line-height-100
-    text-transform: uppercase
     margin-top: $sizing-100
+  


### PR DESCRIPTION
Adds dr--sans for old Lora / uppercase style.