### PR TITLE
Boston.gov/issues/877

### DIFF
--- a/legacy/hub.styl
+++ b/legacy/hub.styl
@@ -2770,10 +2770,9 @@ ol.search-results h4.title a[href$=".txt"] {
     }
 }
 .admin-menu .slicknav_menu {
-    display: none
-}
-.admin-menu a.slicknav_btn.slicknav_collapsed {
-    display: none
+    z-index: 2;
+    position: relative;
+    margin-bottom: -45px;
 }
 @media (min-width: 1026px) {
     .admin-menu header {

--- a/legacy/public.styl
+++ b/legacy/public.styl
@@ -2137,10 +2137,9 @@ section.contact-departments,
     }
 }
 .admin-menu .slicknav_menu {
-    display: none
-}
-.admin-menu a.slicknav_btn.slicknav_collapsed {
-    display: none
+    z-index: 2;
+    position: relative;
+    margin-bottom: -45px;
 }
 @media (min-width: 1026px) {
     .admin-menu header {


### PR DESCRIPTION
This PR is related to https://github.com/CityOfBoston/boston.gov/issues/877

It allows administrators to still view the admin menu when using a tablet or mobile device. Previously this menu was hidden entirely at the 1025px breakpoint.