### PR TITLE
Fix gap between alert and hero.

### DIFF
--- a/legacy/hub.styl
+++ b/legacy/hub.styl
@@ -7227,9 +7227,6 @@ span.field-label+*>*:first-child,
 .page--wa {
     padding-top: 3.5rem
 }
-.page--wa .main {
-    margin-top: 2rem
-}
 .page--wa .hero-image {
     padding-top: 1rem
 }


### PR DESCRIPTION
Fixes https://github.com/CityOfBoston/boston.gov/issues/784 by removing legacy CSS.