### PR TITLE
Form element spacing fixes

### DIFF
--- a/components/base/form/textbox/textbox.config.yml
+++ b/components/base/form/textbox/textbox.config.yml
@@ -7,7 +7,7 @@ context:
   textboxes:
     - label: First name
       placeholder: First name
-      value: Carol Danvers
+      value: Danielle Cage
       id: text
     - label: Email
       placeholder: Your email address

--- a/stylesheets/components/form/_select.styl
+++ b/stylesheets/components/form/_select.styl
@@ -60,11 +60,13 @@
     font-size: inherit
     line-height: $line-height-000
     padding: 0.5em 3.5em 0.5em 1em
-    padding: $sizing-400 85px $sizing-400 $sizing-300
+    padding: $sizing-300 85px $sizing-300 $sizing-300
     width: 100%
+    height: "calc(2 * %s + 2 * %s + %s)" % ($sizing-300 $border-200 1.5rem)
 
     margin: 0
     box-sizing: border-box
+    -moz-appearance: none
     appearance: none
 
     &--sm
@@ -81,6 +83,7 @@
       box-sizing: content-box
       z-index: 2
       width: 0
+      height: 1.5rem
       padding-left: 0
       padding-right: 60px
       overflow: hidden

--- a/stylesheets/components/form/_textbox.styl
+++ b/stylesheets/components/form/_textbox.styl
@@ -28,10 +28,10 @@
     height: auto
     display: block
     font-size: inherit
-    line-height: $line-height-000
+    line-height: $line-height-300
     color: $charles-blue
     border: $border-200 solid $charles-blue
-    padding: $sizing-400 $sizing-300
+    padding: $sizing-300 $sizing-300
     margin: 0
     // fixes Chrome 57 bug of not rendering left/right/bottom of the box shadow
     position: relative

--- a/stylesheets/variables/_line-height.styl
+++ b/stylesheets/variables/_line-height.styl
@@ -1,4 +1,4 @@
 $line-height-000 = 1
 $line-height-100 = 1.1
 $line-height-200 = 1.32
-$line-height-300 = 1.56666666667
+$line-height-300 = 1.5


### PR DESCRIPTION
 - Uses height: calc() on select box to correct the size for Firefox
 - Increases line-height while decreasing padding to keep descenders
   from clipping in Firefox