### PR TITLE
Input height / centering fixes

### DIFF
--- a/components/base/form/textbox/textbox--implicit-input.hbs
+++ b/components/base/form/textbox/textbox--implicit-input.hbs
@@ -1,6 +1,6 @@
 {{#each textboxes as |textbox|}}
   <label class="txt">
     <span class="txt-l">{{label}}</span>
-    <input type="text" value="{{value}}" placeholder="{{placeholder}}" class="txt-f">
+    <input type="text" value="{{value}}" placeholder="{{placeholder}}" class="txt-f{{#if classes}} {{classes}}{{/if}}">
   </label>
 {{/each}}

--- a/components/base/form/textbox/textbox.config.yml
+++ b/components/base/form/textbox/textbox.config.yml
@@ -5,20 +5,40 @@ context:
   inputType: true
   textareaType: false
   textboxes:
-    - label: First name
-      placeholder: First name
+    - label: Full name
+      placeholder: Full name
       value: Danielle Cage
       id: text
     - label: Email
       placeholder: Your email address
       value: ""
-      id: text
+      id: empty-text
+    - label: Small
+      placeholder: Full name
+      value: Steve Rogers
+      id: small-text
+      classes: txt-f--sm
 variants:
   - name: Textarea
     context:
       id: text
       inputType: false
       textareaType: true
+      textboxes:
+        - label: Captains America
+          placeholder: Full names
+          # for textareas we want to see multiple lines
+          value: |+
+            Steve Rogers&
+            Bucky Barnes&
+            Danielle Cage&
+            Samantha Wilson&
+            Steve Mouser
+          id: text
+        - label: Email
+          placeholder: Your email address
+          value: ""
+          id: empty-text
   - name: Error
     context:
       inputType: true

--- a/components/base/form/textbox/textbox.hbs
+++ b/components/base/form/textbox/textbox.hbs
@@ -2,7 +2,7 @@
   <div class="txt">
     <label for="{{id}}" class="txt-l{{#if error }} t--err{{/if}}">{{label}}</label>
     {{#if ../inputType }}
-      <input id="{{id}}" type="text" value="{{value}}" placeholder="{{placeholder}}" class="txt-f{{#if error }} txt-f--err{{/if}}"{{#if size }} size="{{ size }}"{{/if}}>
+      <input id="{{id}}" type="text" value="{{value}}" placeholder="{{placeholder}}" class="txt-f{{#if error }} txt-f--err{{/if}}{{#if classes}} {{classes}}{{/if}}"{{#if size }} size="{{ size }}"{{/if}}>
     {{/if}}
     {{#if ../textareaType }}
       <textarea id="{{id}}" placeholder="{{placeholder}}" class="txt-f" rows="10">{{value}}</textarea>

--- a/stylesheets/components/form/_select.styl
+++ b/stylesheets/components/form/_select.styl
@@ -62,12 +62,16 @@
     padding: 0.5em 3.5em 0.5em 1em
     padding: $sizing-300 85px $sizing-300 $sizing-300
     width: 100%
-    height: "calc(2 * %s + 2 * %s + %s)" % ($sizing-300 $border-200 1.5rem)
+    height: "calc(2 * %s + 2 * %s + %s * 1rem)" % ($sizing-300 $border-200 $line-height-300)
 
     margin: 0
     box-sizing: border-box
     -moz-appearance: none
     appearance: none
+
+    // hides the arrow box on IE10
+    &::-ms-expand
+      display: none
 
     &--sm
       padding-top: $sizing-300
@@ -90,10 +94,6 @@
       text-indent: -9999px
       background: transparent
       
-      // hides the arrow box on IE10
-      &::-ms-expand
-        display: none
-        
     &--err
       border-color: $freedom-red
       color: $freedom-red

--- a/stylesheets/components/form/_textbox.styl
+++ b/stylesheets/components/form/_textbox.styl
@@ -25,13 +25,27 @@
 
   &-f
     font-family: $serif
-    height: auto
     display: block
-    font-size: inherit
-    line-height: $line-height-300
+    font-size: 1rem
+    
+    // Force this for IE, which doesn't pick up on the height needing to be
+    // based on the line-height
+    height: "%srem" % ($line-height-600)
+    line-height: $line-height-600
+
+    // We need the height and the line-height to match up for proper vertical
+    // centering in IE, so we use content-box so we don't need to worry about
+    // accommodating the border.
+    //
+    // We do this instead of using "calc" on the height because Chrome on
+    // Windows will clip descenders when the height is specified as a calc.
+    box-sizing: content-box
+    
     color: $charles-blue
     border: $border-200 solid $charles-blue
-    padding: $sizing-300 $sizing-300
+    // We get all of the height from height / line-height for the
+    // minimum amount of descender clipping in Firefox.
+    padding: 0 $sizing-300
     margin: 0
     // fixes Chrome 57 bug of not rendering left/right/bottom of the box shadow
     position: relative
@@ -40,17 +54,36 @@
       border-color: $freedom-red
 
     &--sm
-      padding: $sizing-200 $sizing-300
+      height: "%srem" % $line-height-400
+      line-height: $line-height-400
 
     input[type=email]&,
     input[type=text]&,
     textarea&
-      width: 100%
+      // Since we're using content-box above, this needs to change to
+      // a calculation to keep the padding / border from going offscreen.
+      // (And we want a width of effectively 100% instead of the arbitrary
+      // size a browser will give an input field, despite it being display:
+      // block)
+      width: 90%
+      width: "calc(100% - 2 * %s - 2 * %s)" % ($sizing-300 $border-200)
 
+    textarea&
+      height: auto
+      line-height: $line-height-300
+      padding: $sizing-200 $sizing-300
+      
     &::placeholder
       font-style: italic
-      color: $grey-400
-      line-height: inherit
+      color: $grey-300
+      line-height: $line-height-600
+
+    textarea&::placeholder
+      line-height: $line-height-300
+
+    &::-ms-clear
+      width: 1rem
+      height: 1rem
 
     &:focus
       box-shadow: 0 0 0 3px $optimistic-blue

--- a/stylesheets/variables/_line-height.styl
+++ b/stylesheets/variables/_line-height.styl
@@ -2,3 +2,6 @@ $line-height-000 = 1
 $line-height-100 = 1.1
 $line-height-200 = 1.32
 $line-height-300 = 1.5
+$line-height-400 = 2
+$line-height-500 = 2.5
+$line-height-600 = 3.5


### PR DESCRIPTION
Changes line height and padding strategy for input fields to ensure centering and no clipping across IE, Firefox, and Chrome Mac and Windows.