### PR TITLE
Changes <select> to use line-height over padding

### DIFF
--- a/stylesheets/base/global/_body.styl
+++ b/stylesheets/base/global/_body.styl
@@ -3,6 +3,7 @@ html, body
   margin: 0
   padding: 0
   color: #58585B
+  font-family: $serif
 
 .no-s
   overflow: hidden

--- a/stylesheets/components/form/_select.styl
+++ b/stylesheets/components/form/_select.styl
@@ -58,9 +58,8 @@
     display: inline-block
     font: inherit
     font-size: inherit
-    line-height: $line-height-000
-    padding: 0.5em 3.5em 0.5em 1em
-    padding: $sizing-300 85px $sizing-300 $sizing-300
+    line-height: $line-height-400
+    padding: 0 85px 0 $sizing-300
     width: 100%
     height: "calc(2 * %s + 2 * %s + %s * 1rem)" % ($sizing-300 $border-200 $line-height-300)
 


### PR DESCRIPTION
Prevents descender clipping in webkit-based browsers.

Also sets the default body font to Lora across the board for the
patterns library.