### PR TITLE
Fix separator for right sidebar items.

### DIFF
--- a/legacy/hub.styl
+++ b/legacy/hub.styl
@@ -7206,10 +7206,8 @@ span.field-label+*>*:first-child,
 .list-item {
     border-top: 0;
     border-right: 0;
-    border-bottom: 1px;
+    border-bottom: 1px dashed #e0e0e0;
     border-left: 0;
-    border-style: dashed;
-    border-color: #e0e0e0;
     padding: 0 0 20px;
     margin: 0 0 20px
 }

--- a/legacy/public.styl
+++ b/legacy/public.styl
@@ -6333,10 +6333,8 @@ span.field-label+*>*:first-child,
 .list-item {
     border-top: 0;
     border-right: 0;
-    border-bottom: 1px;
+    border-bottom: 1px dashed #e0e0e0;
     border-left: 0;
-    border-style: dashed;
-    border-color: #e0e0e0;
     padding: 0 0 20px;
     margin: 0 0 20px
 }


### PR DESCRIPTION
Adds the missing dashed line that separates items in the right sidebar: https://github.com/CityOfBoston/boston.gov/issues/832