### PR TITLE
Omnibus PR for changes needed by death certs

### DIFF
--- a/stylesheets/base/global/_borders.styl
+++ b/stylesheets/base/global/_borders.styl
@@ -13,6 +13,18 @@
   &-t400
     border-top-width: $border-400
 
+  &-b100
+    border-bottom-width: $border-100
+
+  &-b200
+    border-bottom-width: $border-200
+
+  &-b300
+    border-bottom-width: $border-300
+
+  &-b400
+    border-bottom-width: $border-400
+
   &-a100
     border-width: $border-100
 

--- a/stylesheets/base/global/_spacing.styl
+++ b/stylesheets/base/global/_spacing.styl
@@ -363,7 +363,7 @@
       margin-left: auto
   
   &-l000
-    margin-top: $sizing-000
+    margin-left: $sizing-000
 
   &-l100
     margin-left: $sizing-100

--- a/stylesheets/base/global/_text.styl
+++ b/stylesheets/base/global/_text.styl
@@ -1,5 +1,11 @@
 // Text
 .t
+  &--reset
+    color: #58585B
+    font: 16px $serif;
+    text-transform: none;
+    letter-spacing: 0;
+    
   &--intro
     color: $charles-blue
     font-family: $serif

--- a/stylesheets/components/block/_main.styl
+++ b/stylesheets/components/block/_main.styl
@@ -36,6 +36,13 @@
       padding-top: $sizing-300
       padding-bottom: $sizing-300
 
+    // horizontally-small
+    &--hsm
+      // without setting width, if this ends up in a flex container
+      // it will shrink to fit its contents, not go up to max-width
+      width: 100%
+      max-width: 41.25rem
+
     &--ntp
       padding-top: 0
 
@@ -47,6 +54,33 @@
 
     &--wbb
       border-bottom: $border-100 dotted $grey-200
+
+    // Makes a block that "breaks out" of b-c and goes edge-to-edge
+    // (up to the above max-width), replicating the padding inside.
+    // Good for when you want a block to have a background that goes
+    // edge-to-edge.
+    &--hedge {
+      margin-left: -12.5%;
+      margin-right: -12.5%;
+      padding-left: 12.5%;
+      padding-right: 12.5%;
+    }
+
+    // compensates to remove the bottom padding from a b-c parent.
+    &--bedge {
+      margin-bottom: "calc(-1 * %s)" % ($sizing-700)
+    }
+
+  // Flex fill
+  &-ff
+    // Has to be just grow instead of the "flex" shorthand, otherwise
+    // IE won't grow the element to contain its children if they're
+    // taller than the size this is flexing to.
+    flex-grow: 1
+    width: 100%
+    
+    display: flex
+    flex-direction: column
 
   // Block tab
   &-t

--- a/stylesheets/components/form/_button.styl
+++ b/stylesheets/components/form/_button.styl
@@ -50,6 +50,16 @@
   &--b
     display: block
     text-align: center
+    width: 100%
+
+  // Button that fills the remaining space in a flex row
+  &--row
+    flex: 1
+    align-self: stretch
+    // flex behavior should give us the space we need. Set a low
+    // minimum because fitting in with the UI is a higher priority
+    // than the above sizing-400
+    padding: $sizing-100
 
   &--c
     background-color: $charles-blue

--- a/stylesheets/components/form/_checkbox.styl
+++ b/stylesheets/components/form/_checkbox.styl
@@ -62,6 +62,7 @@
       display: block
       // hides the button on iOS
       background: none
+      -moz-appearance: none
       -webkit-appearance: none
 
   &-l
@@ -69,17 +70,13 @@
     font-family: $serif
     font-size: responsive 16px 20px
     font-range: 480px 1440px
-    line-height: 1.4
+    line-height: 1
     margin-left: 7px
     width: calc(100% - 42px)
     text-transform: none
 
     @media $media-medium
-      margin-left: 15px
-
-    @media $media-large
-      // Helps to make sure we're centered at larger font sizes
-      margin-top: -.1em
+      margin-left: 1rem
 
     &--sans
       font-family: $sans

--- a/stylesheets/components/form/_fieldset.styl
+++ b/stylesheets/components/form/_fieldset.styl
@@ -12,8 +12,29 @@
 
 .fs
   border: none
-  margin: 0
+  margin-left: 0
+  margin-right: 0
   padding: 0
+
+  // legend
+  &-l
+    padding: 0
+    margin-bottom: $sizing-200
+
+    text-transform: uppercase
+    // removes the space left for the descenders we don't have
+    // because uppercase
+    line-height: .7
+    font-family: $sans
+    font-size: responsive 16px 20px
+    font-range: 480px 1440px
+    color: $charles-blue
+    display: block
+
+    // legends can't display: flex, so here's a content that can do a flex row
+    &-c
+      display: flex
+      align-items: center
 
   &-c
     @media $media-medium

--- a/stylesheets/components/form/_radio.styl
+++ b/stylesheets/components/form/_radio.styl
@@ -63,6 +63,7 @@
       background: none
       border: none
       -webkit-appearance: none
+      -moz-appearance: none
 
   &-l
     color: $charles-blue

--- a/stylesheets/components/form/_select.styl
+++ b/stylesheets/components/form/_select.styl
@@ -118,6 +118,11 @@ $select-arrow-box-width = 60px
     text-transform: uppercase
     display: block
 
+    &--sm
+      font-size: $font-100
+      font-weight: normal
+      margin-top: 0
+
     &--sq
       display: block
       height: 1px

--- a/stylesheets/components/form/_textbox.styl
+++ b/stylesheets/components/form/_textbox.styl
@@ -58,6 +58,7 @@
       line-height: $line-height-400
 
     input[type=email]&,
+    input[type=phone]&,
     input[type=text]&,
     textarea&
       // Since we're using content-box above, this needs to change to
@@ -75,6 +76,7 @@
         width: "calc(100% - 2 * %s - 3 * %s - %s)" % ($sizing-300 $border-200 $select-arrow-box-width)
 
     input[type=email]&--auto,
+    input[type=phone]&--auto,
     input[type=text]&--auto,
     textarea&--auto
       width: auto
@@ -117,6 +119,11 @@
     letter-spacing: 1px
     text-transform: uppercase
     display: block
+
+    &--sm
+      font-size: $font-100
+      font-weight: normal
+      margin-top: 0
 
     &--mt000
       margin-top: 0

--- a/stylesheets/components/main/_main.styl
+++ b/stylesheets/components/main/_main.styl
@@ -31,6 +31,15 @@
     @media $media-large
       min-height: 100vh
 
+    // IE won't flex children to the size of a min-height'd
+    // flex-direction: column element because of a bug. Wrapping
+    // that element in a row-direction flex element prevents
+    // the bug.
+    //
+    // This element should wrap "mn mn--full" elements
+    &-ie
+      display: flex
+
     // vertically-centered on larger screens
     &-vc
       @media $media-large


### PR DESCRIPTION
 - Adds bottom border classes
 - Fixes incorrect m-l000 definition
 - Adds a t--reset class to allow nesting font styles without inheriting
   transforms and such
 - Adds block styles to allow filling a flex area, making an
   edge-to-edge block inside b-c, and making a thinner-width main block,
   which is better for forms on desktop
 - Adds a fix for IE's behavior with mn--full
 - Makes block buttons take the container width by default, to match
   default block behavior, and adds a button type for matching content
   on a flex row (used by the quantity combo + "add to cart" UI in death
   certs)
 - Fixes checkmarks and radio buttons on FF and adjusts their vertical
   centering to use line-height rather than a margin top for more
   consistent display
 - Modifies fieldset to clear browser default left/right margins while
   still allowing "m-vXXX" classes
 - Adds legend styles under fieldset, based on the step header text
 - Makes "--sm" labels for select and text to match the field labels in
   the death certs checkout process (where the normal labels are tooooo
   big and overkill)
 - Includes the "phone" type in the list of text-like input fields

Potential visible changes:

 - btn--b block-level buttons may get wider
 - Checkbox vertical centering may shift, hopefully for the better
 - Any vertical margin on a fieldset that the .fs class had eliminated
   will return
 - Checkbox and radio buttons will now be styled in Firefox