### PR TITLE
Update _list.styl

### DIFF
--- a/stylesheets/components/detail-list/_list.styl
+++ b/stylesheets/components/detail-list/_list.styl
@@ -43,6 +43,9 @@
     font-style: italic
     line-height: $line-height-200
     width: 20%
+    
+    &--l
+      width: 30%
 
   &-d
     color: $charles-blue
@@ -52,6 +55,9 @@
     line-height: $line-height-200
     text-transform: uppercase
     width: 80%
+    
+    &--s
+      width: 70%
 
     &--tt-n
       text-transform: none


### PR DESCRIPTION
When in a small column (Boston.gov sidebar). Label needs more space. Added modifiers to handle this case.