### PR TITLE
 Two fixes for b-c elements

### DIFF
--- a/stylesheets/components/block/_main.styl
+++ b/stylesheets/components/block/_main.styl
@@ -18,8 +18,10 @@
 .b
   // Block content
   &-c
+    width: 100%
     max-width: 66.67rem
-    margin: 0 auto
+    margin-left: auto
+    margin-right: auto
     padding: $sizing-700 10%
     position: relative
 
@@ -54,22 +56,6 @@
 
     &--wbb
       border-bottom: $border-100 dotted $grey-200
-
-    // Makes a block that "breaks out" of b-c and goes edge-to-edge
-    // (up to the above max-width), replicating the padding inside.
-    // Good for when you want a block to have a background that goes
-    // edge-to-edge.
-    &--hedge {
-      margin-left: -12.5%;
-      margin-right: -12.5%;
-      padding-left: 12.5%;
-      padding-right: 12.5%;
-    }
-
-    // compensates to remove the bottom padding from a b-c parent.
-    &--bedge {
-      margin-bottom: "calc(-1 * %s)" % ($sizing-700)
-    }
 
   // Flex fill
   &-ff


### PR DESCRIPTION
 * Removes resetting the vertical margins to 0. Allows for m-vXXX
   classes on b-c elements.
 * Makes explicit the width: 100% for a block element. Fixes centering
   inside of a flex-column container.

Also removes the "edge" classes, which are not in practice very useful.
Switched registry-certs over to just use full-width divs with b-c
elements inside of them.