### PR TITLE
Adds more line-height to checkboxes and radios

### DIFF
--- a/components/base/form/checkbox/checkbox.hbs
+++ b/components/base/form/checkbox/checkbox.hbs
@@ -1,6 +1,8 @@
+<div style="max-width: 400px; padding: 1em;">
 {{#each checkboxes as |checkbox|}}
   <label class="cb" for="checkbox-{{index}}">
     <input id="checkbox-{{index}}" name="public_notices" type="checkbox" value="public_notices" class="cb-f">
     <span class="cb-l">{{label}}</span>
   </label>
 {{/each}}
+</div>

--- a/components/base/form/radio/radio.hbs
+++ b/components/base/form/radio/radio.hbs
@@ -1,6 +1,8 @@
+<div style="max-width: 400px; padding: 1em;">
 {{#each radios as |radio|}}
   <label class="ra" for="radio[{{index}}]">
     <input id="radio[{{index}}]" type="radio" name="filters" value="{{label}}" class="ra-f">
     <span class="ra-l">{{label}}</span>
   </label>
 {{/each}}
+</div>

--- a/stylesheets/components/form/_checkbox.styl
+++ b/stylesheets/components/form/_checkbox.styl
@@ -70,7 +70,7 @@
     font-family: $serif
     font-size: responsive 16px 20px
     font-range: 480px 1440px
-    line-height: 1
+    line-height: $line-height-150
     margin-left: 7px
     width: calc(100% - 42px)
     text-transform: none

--- a/stylesheets/components/form/_radio.styl
+++ b/stylesheets/components/form/_radio.styl
@@ -70,6 +70,7 @@
     font-family: $serif
     font-size: responsive 16px 20px
     font-range: 480px 1440px
+    line-height: $line-height-150
     margin-left: 7px
     width: calc(100% - 42px)
 

--- a/stylesheets/variables/_line-height.styl
+++ b/stylesheets/variables/_line-height.styl
@@ -1,5 +1,6 @@
 $line-height-000 = 1
 $line-height-100 = 1.1
+$line-height-150 = 1.2
 $line-height-200 = 1.32
 $line-height-300 = 1.5
 $line-height-400 = 2


### PR DESCRIPTION
Makes things look better when lines wrap. Includes div around examples
to ensure that the last one does wrap.

Adds a new "150" line-height because 100 is too small and 200 is too
large when looking at a 2-line wrap with default font sizes.