### PR TITLE
Search form updates

### DIFF
--- a/components/forms/search/search.config.yml
+++ b/components/forms/search/search.config.yml
@@ -2,7 +2,14 @@ title: 'Form: Search'
 handle: form_search
 status: ready
 variants:
+  - name: Default Filled
+    context:
+      term: City Clerk
   - name: Small
+    context:
+      theme: sm
+      show_label: false
+  - name: Small Filled
     context:
       theme: sm
       show_label: false
@@ -11,10 +18,19 @@ variants:
     context:
       theme: md
       show_label: false
+  - name: Medium Filled
+    context:
+      theme: md
+      show_label: false
       term: City Clerk
   - name: Yellow
     context:
       theme: y
+  - name: Yellow Filled
+    context:
+      theme: y
+      term: City Clerk
+
 
 context:
   show_label: true

--- a/stylesheets/components/form/_search.styl
+++ b/stylesheets/components/form/_search.styl
@@ -42,18 +42,17 @@
       font-range: 480px 1440px
       height: auto
       letter-spacing: -1px
-      line-height: 1
+      line-height: 1.3
       margin: 0
-      padding: 0 50px $sizing-100 0
+      padding: 0 50px 0 0
       width: 100%
 
       &:focus
         outline: none
 
       &::placeholder
-        font-style: italic
-        color: $grey-400
-        line-height: 1.2
+        color: $freedom-red
+        opacity: .5
 
     &-b
       background: $icon_search no-repeat center
@@ -96,10 +95,10 @@
   &--md &-i-f
     font-size: responsive 18px 28px
     font-range: 480px 1440px
-    border-bottom-width: $border-200
+    border-bottom-width: $border-150
 
     @media $media-medium
-      border-bottom-width: $border-250
+      border-bottom-width: $border-200
 
   &--md &-i-b
     height: 20px


### PR DESCRIPTION
- Includes both filled and placeholder versions
- Makes the placeholder consistently light red across browsers
  (previously webkit was gray, FF was red)
- Adjusts line height and padding to prevent descenders from being cut
  off
- Makes the medium border not as thick