### PR TITLE
Updates Stencil to 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,9 @@
       }
     },
     "@stencil/core": {
-      "version": "github:CityOfBoston/stencil#ebf5e2bc541feea47dc5330c3b72ec1eba15654b",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-0.4.0.tgz",
+      "integrity": "sha512-gdfis9cmvxY3xNzEVK/K6t7Z+eAXfDeDTtgTdMhfHhVhgfrT2uBwzw9hEqwlg6wrSYtCChKG7TdJVI952DTVMg==",
       "requires": {
         "chokidar": "2.0.0",
         "jsdom": "11.5.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@frctl/fractal": "^1.1.4",
-    "@stencil/core": "github:CityOfBoston/stencil",
+    "@stencil/core": "^0.4.0",
     "@types/esri-leaflet": "^2.1.2",
     "@types/geojson": "^7946.0.1",
     "@types/jest": "^22.1.1",

--- a/stencil.config.js
+++ b/stencil.config.js
@@ -2,10 +2,10 @@ exports.config = {
   srcDir: 'web-components',
 
   namespace: 'all',
-  bundles: [
-    { components: ['cob-contact-form'] },
-    { components: ['cob-map', 'cob-map-legend', 'cob-map-esri-layer'] },
-  ],
+
+  // Re-enable after https://github.com/ionic-team/stencil/issues/468 is sorted
+  // out.
+  serviceWorker: false,
 
   // URL where we want our components, index.html, and sw.js to live
   publicPath: '/web-components/',

--- a/web-components/components.d.ts
+++ b/web-components/components.d.ts
@@ -5,12 +5,21 @@
  */
 
 
+declare global {
+  interface HTMLStencilElement extends HTMLElement {
+    componentOnReady(): Promise<this>;
+    componentOnReady(done: (ele?: this) => void): void;
+  }
+}
+
+
+
 import {
   ContactForm as CobContactForm
 } from './contact-form/contact-form';
 
 declare global {
-  interface HTMLCobContactFormElement extends CobContactForm, HTMLElement {
+  interface HTMLCobContactFormElement extends CobContactForm, HTMLStencilElement {
   }
   var HTMLCobContactFormElement: {
     prototype: HTMLCobContactFormElement;
@@ -44,7 +53,7 @@ import {
 } from './map-esri-layer/map-esri-layer';
 
 declare global {
-  interface HTMLCobMapEsriLayerElement extends CobMapEsriLayer, HTMLElement {
+  interface HTMLCobMapEsriLayerElement extends CobMapEsriLayer, HTMLStencilElement {
   }
   var HTMLCobMapEsriLayerElement: {
     prototype: HTMLCobMapEsriLayerElement;
@@ -77,7 +86,7 @@ import {
 } from './map-legend/map-legend';
 
 declare global {
-  interface HTMLCobMapLegendElement extends CobMapLegend, HTMLElement {
+  interface HTMLCobMapLegendElement extends CobMapLegend, HTMLStencilElement {
   }
   var HTMLCobMapLegendElement: {
     prototype: HTMLCobMapLegendElement;
@@ -108,7 +117,7 @@ import {
 } from './map/map';
 
 declare global {
-  interface HTMLCobMapElement extends CobMap, HTMLElement {
+  interface HTMLCobMapElement extends CobMap, HTMLStencilElement {
   }
   var HTMLCobMapElement: {
     prototype: HTMLCobMapElement;


### PR DESCRIPTION
Disables the service worker temporarily due to ionic-team/stencil#468,
but it's better to be on an official release than our GitHub fork.