### PR TITLE
Removes "baseurl" from Percy config

### DIFF
--- a/travis/percy.sh
+++ b/travis/percy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-percy snapshot public --baseurl "/components" --snapshots_regex="(components\/preview.).*\.html$" --enable_javascript --trace --widths "375,1024,1280"
+percy snapshot public --snapshots_regex="(components\/preview.).*\.html$" --enable_javascript --trace --widths "375,1024,1280"


### PR DESCRIPTION
Allows Percy to find assets referenced as absolute paths (rather than
just the ../ relative paths). Will make SVGs and JS appear.

As a one-time change, will invalidate all screenshots because the paths
are changing.