### PR TITLE
Adds support for popup templates to cob-map

### DIFF
--- a/components/blocks/detail-list/detail-list.config.yml
+++ b/components/blocks/detail-list/detail-list.config.yml
@@ -12,3 +12,8 @@ context:
     - icon: false
       name: Updated
       description: 11/27/2016 - 10:45AM
+
+variants:
+  - name: Small
+    context:
+      small: true

--- a/components/blocks/detail-list/detail-list.hbs
+++ b/components/blocks/detail-list/detail-list.hbs
@@ -1,4 +1,4 @@
-<ul class="dl">
+<ul class="dl{{#if small}} dl--sm{{/if}}">
   {{#each details as |detail|}}
     <li class="dl-i">
       <span class="dl-t">{{ detail.name }}</span>

--- a/components/web-components/map/README.md
+++ b/components/web-components/map/README.md
@@ -5,7 +5,7 @@ of nested components.
 
 ### Attributes
 
-**title**: Title for the map. Shown on the collapse / expand header at mobile
+**heading**: Title for the map. Shown on the collapse / expand header at mobile
 widths.
 
 **latitude** / **longitude**: Position to center the map on to start. Will be
@@ -22,6 +22,9 @@ overlay.
 
 **show-address-search**: Boolean attribute for whether to put a search box for
 addresses in the overlay.
+
+**address-search-heading**: Header to show above the address search box. Defaults
+to “Address search”
 
 **address-search-placeholder**: String to use as the placeholder in the address
 search box (if visible). Defaults to “Search for an address…”
@@ -44,7 +47,7 @@ features on the map. They take the following properties:
 
 **url**: URL for an ArcGIS feature layer.
 
-**title**: String to show on the legend for this layer.
+**label**: String to show on the legend for this layer.
 
 **icon-src**: URL to use as an icon for the layer’s features, and to show in the
 legend for this layer.
@@ -52,4 +55,20 @@ legend for this layer.
 **color**: For polygon layers, the color for the borders. (The fill will be a
 semi-transparent version of this color).
 
-**hover-color**: If set, the color to use for polygon borders if the mouse is hovered over them.
+**hover-color**: If set, the color to use for polygon borders if the mouse is
+hovered over them.
+
+**fill**: Boolean attribute. If set, regions will be filled in with the color
+attribute at 20% opacity. Also causes the legend to show a box rather than a
+straight line for this layer.
+
+**popup-template**: A Mustache template to use to generate the contents of a
+Leaflet popup for the layer’s features. Its context will be the feature’s
+properties. To specify the template in a more editor-friendly way, use the
+`popup` slot and a `<script>` tag.
+
+### Slots
+
+**popup**: Alternate way to define the popup template that avoids the need to
+HTML escape tags and quotes. Include a `<script slot="popup"
+type="text/mustache">` element whose text contents are a Mustache template. 

--- a/components/web-components/map/map.config.yml
+++ b/components/web-components/map/map.config.yml
@@ -2,7 +2,7 @@ title: 'Web Components: Map'
 handle: map
 status: ready
 context:
-  title: Parking and city councilors
+  heading: Parking and city councilors
 variants:
   - name: Address Search
     context:

--- a/components/web-components/map/map.hbs
+++ b/components/web-components/map/map.hbs
@@ -1,21 +1,56 @@
-<cob-map
-  title="{{title}}"
+<cob-map heading="{{heading}}"
   style="height: 500px"
   latitude="42.347316"
   longitude="-71.065227"
   zoom="12"
   show-zoom-control
-  show-legend{{#if show_address_search}}
-  show-address-search{{/if}}{{#if open_overlay}}
+  show-legend{{#if
+  show_address_search}}
+  show-address-search{{/if}}{{#if
+  open_overlay}}
   open-overlay{{/if}}>
   <cob-map-esri-layer url="https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/City_Council_Districts/FeatureServer/0"
-    color="#0C2639" hover-color="#FB4D42" title="Boston City Council districts" interactive></cob-map-esri-layer>
+    color="#0C2639"
+    hover-color="#FB4D42"
+    label="Boston City Council Districts"
+    fill>
+    <script slot="popup" type="text/mustache">
+      <img src="\{{Image}}" class="cdp-i" alt="\{{Councilor}}" style="margin-bottom: 1rem"/>
+      <div class="ta-c m-v300">
+        <div class="cdp-t t--sans t--upper m-t200">\{{Councilor}}</div>
+        <div class="cdp-st t--subinfo t--g300">District \{{DISTRICT}}</div>
+      </div>
+      <a href="\{{Bio}}" class="d-b bg--cb cdp-a ta-c p-a200 t--upper t--sans t--w t--ob--h t--s100">Visit webpage<span class="a11y--h"> of {{Councillor}}</span></a>
+    </script>
+  </cob-map-esri-layer>
+  <cob-map-esri-layer url="https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/Ownership/FeatureServer/0"
+    color="#e1453b"
+    label="Snow Emergency Restricted Parking"></cob-map-esri-layer>
   <cob-map-esri-layer url="https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/SnowParking/FeatureServer/0"
-    icon-src="/images/global/icons/mapping/parking.svg" title="Snow Emergency Parking Lots"></cob-map-esri-layer>
-{{#unless show_address_search}}  <div class="t--info" slot="instructions">
+    icon-src="/images/global/icons/mapping/parking.svg"
+    label="Snow Emergency Parking Lots">
+    <script slot="popup"
+      type="text/mustache">
+      <div style="min-width: 280px">
+        <h3 class="h3 m-v300">\{{Address}}</h4>
+        <div class="m-v300">
+          <ul class="dl dl--sm">
+            <li class="dl-i"><span class="dl-t">Name:</span> <span class="dl-d">\{{Name}}</span></li>
+            <li class="dl-i"><span class="dl-t">Fee:</span> <span class="dl-d">\{{Fee}}</span></li>
+          </ul>
+        </div>
+        \{{#Comments}}<div class="t--subinfo m-v300">\{{.}}</div>\{{/Comments}}
+        \{{#Phone}}<div class="t--subinfo m-v300">Call ahead to find out the number of spaces available: <a href="tel:\{{.}}">\{{.}}</a></div>\{{/Phone}}
+      </div>
+    </script>
+  </cob-map-esri-layer>
+  {{#unless show_address_search}}
+  <div class="t--info"
+    slot="instructions">
     <p class="m-t000">Hover over and click on your district to find your councilor, or search your address.</p>
     <p>To see all City Council members, including at-large councilors, visit the
-      <a target="_blank" href="https://www.boston.gov/departments/city-council#city-council-members">City Council page.</a>
+      <a target="_blank"
+        href="https://www.boston.gov/departments/city-council#city-council-members">City Council page.</a>
     </p>
   </div>
-{{/unless}}</cob-map>
+  {{/unless}}</cob-map>

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,18 +126,18 @@
       }
     },
     "@stencil/core": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-0.5.1.tgz",
-      "integrity": "sha512-UcP72UzBlTJxVyE02VdLW6Ot22V/5an0FZ/CwwnsWYHF90Sim0KQzM7qNoi3SLnmeZcVOZ8IVf6NDScuvthwOw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-0.5.2.tgz",
+      "integrity": "sha512-hpcPxiYd9LTthtrhAo58/UdtsjAgYEYdVIMY9TZ+45+a+CkcBwjYfKTpsNaprCMLsUWYJQmQujoHoAkdqpVluw==",
       "requires": {
         "chokidar": "2.0.1",
         "jsdom": "11.5.1",
         "node-sass": "4.7.2",
-        "rollup": "0.55.3",
+        "rollup": "0.55.5",
         "rollup-plugin-commonjs": "8.3.0",
         "rollup-plugin-node-builtins": "2.1.2",
         "rollup-plugin-node-globals": "1.1.0",
-        "rollup-plugin-node-resolve": "3.0.2",
+        "rollup-plugin-node-resolve": "3.0.3",
         "typescript": "2.7.1",
         "uglify-es": "3.3.9",
         "workbox-build": "3.0.0-alpha.6"
@@ -3004,9 +3004,9 @@
       "dev": true
     },
     "errno": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
-      "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
         "prr": "1.0.1"
       }
@@ -8010,7 +8010,7 @@
       "integrity": "sha1-oArKmRnEpN+v3KaoEI0iWq3/Y7M=",
       "requires": {
         "concat-stream": "1.6.0",
-        "errno": "0.1.6",
+        "errno": "0.1.7",
         "fwd-stream": "1.0.4",
         "level-blobs": "0.1.7",
         "level-peek": "1.0.6",
@@ -8128,7 +8128,7 @@
       "requires": {
         "bl": "0.8.2",
         "deferred-leveldown": "0.2.0",
-        "errno": "0.1.6",
+        "errno": "0.1.7",
         "prr": "0.0.0",
         "readable-stream": "1.0.34",
         "semver": "2.3.2",
@@ -12480,9 +12480,9 @@
       }
     },
     "rollup": {
-      "version": "0.55.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.55.3.tgz",
-      "integrity": "sha512-2TgimJ7pk+XfPT0DmAcOqq9qdXlJ04qKyzyLm1WvPS/E6XdXEXyG5u6L8AsjxOaKoEBlYGliPzo99jxwhn2NYQ=="
+      "version": "0.55.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.55.5.tgz",
+      "integrity": "sha512-2hke9NOy332kxvnmMQOgl7DHm94zihNyYJNd8ZLWo4U0EjFvjUkeWa0+ge+70bTg+mY0xJ7NUsf5kIhDtrGrtA=="
     },
     "rollup-plugin-commonjs": {
       "version": "8.3.0",
@@ -12550,9 +12550,9 @@
       }
     },
     "rollup-plugin-node-resolve": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.2.tgz",
-      "integrity": "sha512-ZwmMip/yqw6cmDQJuCQJ1G7gw2z11iGUtQNFYrFZHmqadRHU+OZGC3nOXwXu+UTvcm5lzDspB1EYWrkTgPWybw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.3.tgz",
+      "integrity": "sha512-qJLXJ1aASV6p8SrEfRdQdHmb5OQmqXyIWIdVGcju8QFzftSsHcuL554Vy+n8mr0fZCC+ksO6aWJ7TAVl2F+Qwg==",
       "requires": {
         "builtin-modules": "1.1.1",
         "is-module": "1.0.0",
@@ -13806,6 +13806,9 @@
         "fstream": "1.0.11",
         "inherits": "2.0.3"
       }
+    },
+    "templayed": {
+      "version": "github:CityOfBoston/templayed.js#ca27f5bf908043722a7d0f97345e462b5679fcc3"
     },
     "test-exclude": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@frctl/fractal": "^1.1.4",
-    "@stencil/core": "^0.5.1",
+    "@stencil/core": "^0.5.2",
     "@types/geojson": "^7946.0.1",
     "@types/jest": "^22.1.1",
     "@types/leaflet": "^1.2.5",
@@ -42,7 +42,8 @@
     "require-dir": "^0.3.0",
     "rucksack-css": "^0.9.1",
     "run-sequence": "^1.2.2",
-    "serve-static": "^1.11.1"
+    "serve-static": "^1.11.1",
+    "templayed": "github:CityOfBoston/templayed.js"
   },
   "devDependencies": {
     "eslint": "^4.17.0",

--- a/stylesheets/base/global/_headings.styl
+++ b/stylesheets/base/global/_headings.styl
@@ -20,3 +20,12 @@ h1, h2, h3, h4, h5, h6
   font-weight: 700
   line-height: $line-height-000
   margin: 0
+
+.h3
+  color: $charles-blue
+  font-family: $sans
+  font-size: responsive 16px 20px
+  font-range: 480px 1440px
+  font-weight: 700
+  line-height: $line-height-000
+  margin: 0

--- a/stylesheets/components/detail-list/_list.styl
+++ b/stylesheets/components/detail-list/_list.styl
@@ -12,6 +12,7 @@
 
    Modifier:
     b = block
+    sm = small (less vertical spacing)
 
  */
 
@@ -30,9 +31,15 @@
     &:not(:first-child)
       padding-top: $sizing-300
 
+    .dl--sm &:not(:first-child)
+      padding-top: $sizing-100
+
     &:not(:last-child)
       border-bottom: 1px dashed $grey-100
       padding-bottom: $sizing-300
+
+    .dl--sm &:not(:last-child)
+      padding-bottom: $sizing-100
 
     &--b
       line-height: 1
@@ -62,7 +69,10 @@
     float: left
     font-family: $sans
     font-size: responsive $font-100 $font-200
-    line-height: $line-height-200
+    // Keeps the line-height relative to the responsive font-size, but
+    // compensates for the dl-t font size being bigger. Aims to preserve
+    // vertical centering.
+    line-height: "calc(%s * 1.25)" % ($line-height-200)
     text-transform: uppercase
     width: 80%
     

--- a/web-components/components.d.ts
+++ b/web-components/components.d.ts
@@ -73,9 +73,11 @@ declare global {
   namespace JSXElements {
     export interface CobMapEsriLayerAttributes extends HTMLAttributes {
       color?: string;
+      fill?: boolean;
       hoverColor?: string;
       iconSrc?: string;
-      title?: string;
+      label?: string;
+      popupTemplate?: string;
       url?: string;
     }
   }
@@ -106,15 +108,16 @@ declare global {
   }
   namespace JSXElements {
     export interface CobMapAttributes extends HTMLAttributes {
+      addressSearchHeading?: string;
       addressSearchPlaceholder?: string;
       basemapUrl?: string;
+      heading?: string;
       latitude?: number;
       longitude?: number;
       openOverlay?: boolean;
       showAddressSearch?: boolean;
       showLegend?: boolean;
       showZoomControl?: boolean;
-      title?: string;
       zoom?: number;
     }
   }

--- a/web-components/index.html
+++ b/web-components/index.html
@@ -50,13 +50,43 @@
         show-zoom-control
         show-legend
         show-address-search
-        title="Snow Emergency Parking Restrictions">
+        address-search-heading="Nearby routes and parking"
+        heading="Snow Emergency Parking Restrictions">
+        <cob-map-esri-layer url="https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/City_Council_Districts/FeatureServer/0"
+          color="#0C2639"
+          hover-color="#FB4D42"
+          label="Boston City Council Districts"
+          fill>
+          <script slot="popup" type="text/mustache">
+            <img src="{{Image}}" class="cdp-i" alt="{{Councilor}}" style="margin-bottom: 1rem"/>
+            <div class="ta-c m-v300">
+              <div class="cdp-t t--sans t--upper m-t200">{{Councilor}}</div>
+              <div class="cdp-st t--subinfo t--g300">District {{DISTRICT}}</div>
+            </div>
+            <a href="{{Bio}}" class="d-b bg--cb cdp-a ta-c p-a200 t--upper t--sans t--w t--ob--h t--s100">Visit webpage<span class="a11y--h"> of {{Councillor}}</span></a>
+          </script>
+        </cob-map-esri-layer>
         <cob-map-esri-layer url="https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/Ownership/FeatureServer/0"
           color="#e1453b"
-          title="Snow Emergency Restricted Parking"></cob-map-esri-layer>
+          label="Snow Emergency Restricted Parking"></cob-map-esri-layer>
         <cob-map-esri-layer url="https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/SnowParking/FeatureServer/0"
           icon-src="/images/global/icons/mapping/parking.svg"
-          title="Snow Emergency Parking Lots"></cob-map-esri-layer>
+          label="Snow Emergency Parking Lots">
+          <script slot="popup"
+            type="text/mustache">
+            <div style="min-width: 280px">
+              <h3 class="h3 m-v300">{{ Address }}</h4>
+              <div class="m-v300">
+                <ul class="dl dl--sm">
+                  <li class="dl-i"><span class="dl-t">Name:</span> <span class="dl-d">{{Name}}</span></li>
+                  <li class="dl-i"><span class="dl-t">Fee:</span> <span class="dl-d">{{Fee}}</span></li>
+                </ul>
+              </div>
+              {{#Comments}}<div class="t--subinfo m-v300">{{.}}</div>{{/Comments}}
+              {{#Phone}}<div class="t--subinfo m-v300">Call ahead to find out the number of spaces available: <a href="tel:{{.}}">{{.}}</a></div>{{/Phone}}
+            </div>
+          </script>
+        </cob-map-esri-layer>
       </cob-map>
     </div>
   </div>

--- a/web-components/map-esri-layer/map-esri-layer.tsx
+++ b/web-components/map-esri-layer/map-esri-layer.tsx
@@ -1,4 +1,4 @@
-import { Component, Event, Prop, EventEmitter } from '@stencil/core';
+import { Component, Element, Event, Prop, EventEmitter } from '@stencil/core';
 
 import { LayerConfig } from '../map/map';
 
@@ -6,11 +6,20 @@ import { LayerConfig } from '../map/map';
   tag: 'cob-map-esri-layer',
 })
 export class CobMapEsriLayer {
+  @Element() el: HTMLElement;
+
   @Prop() url: string;
-  @Prop() title: string;
+  @Prop() label: string;
   @Prop() color: string = '';
   @Prop() hoverColor: string = '';
   @Prop() iconSrc: string = '';
+  @Prop() fill: boolean = false;
+
+  // We allow either a string attribute or a nested <script> tag to define the
+  // template for popups. The attribute is more correct and better for DOM
+  // generation, but the <script> is supported for easier human-editing (since
+  // the attribute version requires much escaping for <>s).
+  @Prop() popupTemplate: string = '';
 
   @Event() cobMapEsriLayerConfig: EventEmitter;
 
@@ -24,12 +33,17 @@ export class CobMapEsriLayer {
   }
 
   emitConfig() {
+    const popupScript = this.el.querySelector('script[slot=popup]');
+
     const config: LayerConfig = {
       url: this.url,
-      title: this.title,
+      label: this.label,
       color: this.color,
       hoverColor: this.hoverColor,
+      fill: this.fill,
       iconSrc: this.iconSrc,
+      popupTemplate:
+        this.popupTemplate || (popupScript && popupScript.innerHTML),
     };
 
     this.cobMapEsriLayerConfig.emit(config);

--- a/web-components/map/map.css
+++ b/web-components/map/map.css
@@ -2,6 +2,12 @@ cob-map {
   display: block;
 }
 
+cob-map.leaflet-container a.leaflet-popup-close-button {
+  /* By default this is too tight in the corner */
+  top: 6px;
+  right: 6px;
+}
+
 cob-map .cob-overlay {
   cursor: default;
 
@@ -100,6 +106,7 @@ cob-map .geocoder-control-suggestions .geocoder-control-suggestion:hover {
 }
 
 cob-map .cob-overlay-content .sf-i-b {
+  /* clicking the icon doesn't do a search, so don't make it look like it does */
   cursor: default;
 }
 
@@ -108,12 +115,13 @@ cob-map .cob-legend-table-row {
   align-items: center;
 }
 
-cob-map .cob-legend-table-icon {
-  margin-right: 0.5rem;
+cob-map .cob-legend-table-icon img {
+  display: block;
 }
 
 cob-map .cob-legend-table-label {
   flex: 1;
   line-height: 1.2;
-  margin-top: -2px;
+  margin-top: -3px;
+  margin-left: 0.5rem;
 }


### PR DESCRIPTION
Popup templates are specified at the layer level as Mustache templates.

Also:
 - Adds .h3 class for smaller headings
 - Adds small dl variant and tweaks vertical centering
 - Changes "title" to "heading" or "label" as appropriate to avoid
   conflicting with default HTML title behavior