### PR TITLE
Adds icon clustering via Leaflet.markercluster

### DIFF
--- a/components/web-components/map/README.md
+++ b/components/web-components/map/README.md
@@ -54,6 +54,10 @@ features on the map.
 **icon-src**: URL to use as an icon for the layer’s features, and to show in the
 legend for this layer.
 
+**cluster-icons**: If the layer is showing icons, use the
+[markercluster](https://github.com/CityOfBoston/Leaflet.markercluster) Leaflet
+plugin to show nearby icons as a single dot until you zoom in.
+
 **color**: For polygon layers, the color for the borders. (The fill will be a
 semi-transparent version of this color).
 

--- a/components/web-components/map/map.config.yml
+++ b/components/web-components/map/map.config.yml
@@ -9,6 +9,10 @@ variants:
       show_address_search: true
       open_overlay: true
 
+  - name: Cluster Icons
+    context:
+      cluster_icons: true
+
   - name: Overlay Open
     context:
       open_overlay: true

--- a/components/web-components/map/map.hbs
+++ b/components/web-components/map/map.hbs
@@ -27,7 +27,8 @@
     color="#e1453b"
     label="Snow Emergency Restricted Parking"></cob-map-esri-layer>
   <cob-map-esri-layer url="https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/SnowParking/FeatureServer/0"
-    icon-src="/images/global/icons/mapping/parking.svg"
+    icon-src="/images/global/icons/mapping/parking.svg"{{#if cluster_icons}}
+    cluster-icons{{/if}}
     label="Snow Emergency Parking Lots">
     <script slot="popup"
       type="text/mustache">

--- a/package-lock.json
+++ b/package-lock.json
@@ -8095,6 +8095,9 @@
         "leaflet": "github:CityOfBoston/leaflet#fb8ca7192921a9d659e2c467145888e1b96fa409"
       }
     },
+    "leaflet.markercluster": {
+      "version": "github:CityOfBoston/Leaflet.markercluster#b2235347e901a4e23772381f3ded614bd939212d"
+    },
     "left-pad": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "gulp-uglify": "^3.0.0",
     "laggard": "^0.1.0",
     "leaflet": "github:CityOfBoston/leaflet#dist",
+    "leaflet.markercluster": "github:CityOfBoston/Leaflet.markercluster#dist",
     "lost": "^8.1.0",
     "postcss": "^6.0.17",
     "postcss-flexibility": "^1.1.0",

--- a/web-components/components.d.ts
+++ b/web-components/components.d.ts
@@ -72,6 +72,7 @@ declare global {
   }
   namespace JSXElements {
     export interface CobMapEsriLayerAttributes extends HTMLAttributes {
+      clusterIcons?: boolean;
       color?: string;
       fill?: boolean;
       hoverColor?: string;

--- a/web-components/html/index.html
+++ b/web-components/html/index.html
@@ -40,14 +40,15 @@
         <h2>
           <code>&lt;cob-viz&gt;</code>
         </h2>
+      </div>
 
-        <cob-viz map-style="min-height: 500px"
-          map-class="m-v500"
-          map-onmouseover="console.log('mouseover')"
-          map-show-address-search
-          map-zoom="11">
-          <script slot="config"
-            type="application/json">
+      <cob-viz map-style="min-height: 500px"
+        map-class="m-v500"
+        map-onmouseover="console.log('mouseover')"
+        map-show-address-search
+        map-zoom="11">
+        <script slot="config"
+          type="application/json">
             {
               "vizId": "123456",
               "title": "What is my title",
@@ -65,7 +66,7 @@
                 "popover": "<p>I am a popover</p>",
                 "attributes":
                 {
-                  "service": "https://services.arcgis.com/sFnw0xNflSi8J0uh/ArcGIS/rest/services/food_trucks_schedule/FeatureServer",
+                  "service": "https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/public_bathrooms/FeatureServer",
                   "layer": 0
                 },
                 "legend_label": "I am a legend!"
@@ -85,8 +86,7 @@
               }]
             }
           </script>
-        </cob-viz>
-      </div>
+      </cob-viz>
     </div>
 
     <div class="b-c b-c--xsmv b--w m-v100">
@@ -107,6 +107,7 @@
         address-search-heading="Nearby routes and parking"
         heading="Snow Emergency Parking Restrictions">
         <cob-map-esri-layer url="https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/City_Council_Districts/FeatureServer/0"
+      
           color="#0C2639"
           hover-color="#FB4D42"
           label="Boston City Council Districts"
@@ -144,7 +145,7 @@
         </cob-map-esri-layer>
       </cob-map>
     </div>
-   </div>
+  </div>
 </body>
 
 </html>

--- a/web-components/map-esri-layer/map-esri-layer.tsx
+++ b/web-components/map-esri-layer/map-esri-layer.tsx
@@ -14,6 +14,7 @@ export class CobMapEsriLayer {
   @Prop() hoverColor: string = '';
   @Prop() iconSrc: string = '';
   @Prop() fill: boolean = false;
+  @Prop() clusterIcons: boolean = false;
 
   // We allow either a string attribute or a nested <script> tag to define the
   // template for popups. The attribute is more correct and better for DOM
@@ -42,6 +43,7 @@ export class CobMapEsriLayer {
       hoverColor: this.hoverColor,
       fill: this.fill,
       iconSrc: this.iconSrc,
+      clusterIcons: this.clusterIcons,
       popupTemplate:
         this.popupTemplate || (popupScript && popupScript.innerHTML),
     };

--- a/web-components/map/map.css
+++ b/web-components/map/map.css
@@ -125,3 +125,49 @@ cob-map .cob-legend-table-label {
   margin-top: -3px;
   margin-left: 0.5rem;
 }
+
+cob-map .marker-cluster-small {
+  background-color: rgba(40, 139, 228, 0.6);
+}
+
+cob-map .marker-cluster-small div {
+  background-color: rgba(40, 139, 228, 0.6);
+}
+
+cob-map .marker-cluster-medium {
+  background-color: rgba(40, 139, 228, 0.6);
+}
+
+cob-map .marker-cluster-medium div {
+  background-color: rgba(40, 139, 228, 0.6);
+}
+
+cob-map .marker-cluster-large {
+  background-color: rgba(40, 139, 228, 0.6);
+}
+
+cob-map .marker-cluster-large div {
+  background-color: rgba(40, 139, 228, 0.6);
+}
+
+cob-map .marker-cluster {
+  background-clip: padding-box;
+  border-radius: 20px;
+}
+
+cob-map .marker-cluster div {
+  width: 30px;
+  height: 30px;
+  margin-left: 5px;
+  margin-top: 5px;
+
+  text-align: center;
+  border-radius: 15px;
+
+  font-weight: bold;
+  color: white;
+}
+
+.marker-cluster span {
+  line-height: 30px;
+}

--- a/web-components/viz/viz.tsx
+++ b/web-components/viz/viz.tsx
@@ -189,10 +189,12 @@ export class CobViz {
                 legend_label,
                 popover,
                 polygon_style,
+                cluster_icons,
               }) => (
                 <cob-map-esri-layer
                   url={`${service}/${layer}`}
                   iconSrc={icon}
+                  clusterIcons={cluster_icons}
                   popupTemplate={popover}
                   label={legend_label}
                   color={polygon_style.color}


### PR DESCRIPTION
 - Switches our Esri feature loading to use a query directly since
   Esri's FeatureLayer is incompatible with MarkerClusterGroup.
 - Cleans up imports a bit to not use the Leaflet convenience
   constructors.