### PR TITLE
Disables Percy on production branch

### DIFF
--- a/travis/invalidate_cache.sh
+++ b/travis/invalidate_cache.sh
@@ -2,12 +2,6 @@
 
 set -o errexit -o nounset
 
-if [ "$TRAVIS_BRANCH" != "master" ]
-then
-  echo "This commit was made against the $TRAVIS_BRANCH and not the master! No deploy!"
-  exit 0
-fi
-
 # Invalidate CloudFront distribution
 pip install --upgrade --user awscli
 aws configure set preview.cloudfront true

--- a/travis/percy.sh
+++ b/travis/percy.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-percy snapshot public --snapshots_regex="(components\/preview.).*\.html$" --enable_javascript --trace --widths "375,1024,1280"
+if [ "$TRAVIS_BRANCH" != "production" ]
+then
+  percy snapshot public --snapshots_regex="(components\/preview.).*\.html$" --enable_javascript --trace --widths "375,1024,1280"
+fi


### PR DESCRIPTION
Fix for #245

Also removes unnecessary (and never triggered) branch check for
invalidating the cache. Travis only runs the script after a deploy in
any case.