### PR TITLE
Reference city council map with web-components

### DIFF
--- a/web-components/html/city-council.html
+++ b/web-components/html/city-council.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html dir="ltr"
+  lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport"
+    content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
+  <title>Boston City Council</title>
+
+  <!--[if !IE]><!-->
+  <link rel="stylesheet"
+    type="text/css"
+    href="/css/public.css" />
+  <!--<![endif]-->
+  <!--[if lt IE 10]>
+    <link media="all" rel="stylesheet" href="/css/ie.css">
+  <![endif]-->
+
+</head>
+
+<body>
+  <div class="b b-c">
+
+    <div class="sh m-b500">
+      <a name="councilor-look-up"
+        data-text="Councilor look-up"
+        class="subnav-anchor createNavItem-processed"></a>
+      <h2 class="sh-title">City councilor map look-up</h2>
+    </div>
+
+    <cob-map id="map"
+      style="height: 600px"
+      latitude="42.347316"
+      longitude="-71.065227"
+      zoom="12"
+      show-zoom-control
+      show-legend
+      show-address-search
+      address-search-heading=""
+      address-search-placeholder="Search for your address…"
+      heading="City Councilor Look-Up">
+      <div slot="instructions"
+        class="t--info">
+        <p>
+          Hover over and click on your district to find your councilor, or search your address.
+        </p>
+        <p>
+          To see all City Council members, including at-large councilors, visit the
+          <a href="https://www.boston.gov/departments/city-council#city-council-members">City Council page</a>.
+        </p>
+
+      </div>
+      <cob-map-esri-layer url="https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/City_Council_Districts/FeatureServer/0"
+    
+        color="#0C2639"
+        hover-color="#FB4D42"
+        label="Boston City Council Districts"
+        fill>
+        <script slot="popup"
+          type="text/mustache">
+          <img src="{{Image}}" class="cdp-i" alt="{{Councilor}}" style="margin-bottom: 1rem"/>
+          <div class="ta-c m-v300">
+            <div class="cdp-t t--sans t--upper m-t200">{{Councilor}}</div>
+            <div class="cdp-st t--subinfo t--g300">District {{DISTRICT}}</div>
+          </div>
+          <a href="{{Bio}}" class="btn btn--b btn--100 btn--sm">
+            Visit webpage<span class="a11y--h"> of {{Councillor}}</span>
+          </a>
+        </script>
+      </cob-map-esri-layer>
+    </cob-map>
+  </div>
+
+  <script src="/web-components/all.js"></script>
+</body>
+
+</html>

--- a/web-components/map/map.tsx
+++ b/web-components/map/map.tsx
@@ -484,7 +484,11 @@ export class CobMap {
             {this.showLegend && (
               <div class="g cob-legend-table">
                 {this.layerConfigs.map(config => (
-                  <div class="g--6 cob-legend-table-row m-b200">
+                  <div
+                    class={`${
+                      this.layerConfigs.length === 1 ? 'g--12' : 'g--6'
+                    } cob-legend-table-row m-b200`}
+                  >
                     <div class="cob-legend-table-icon">
                       {this.renderLegendIcon(config)}
                     </div>


### PR DESCRIPTION
Gives us a baseline to examine design before going live on Boston.gov
(implementation for #255)

Also updates the legend to use full-width when there’s only one layer.