### PR TITLE
Adds polyfills to Fractal

### DIFF
--- a/fractal.js
+++ b/fractal.js
@@ -105,6 +105,7 @@ const mandelbrot = require('@frctl/mandelbrot');
 const fleetTheme = mandelbrot({
   skin: 'blue',
   panels: ['html', 'info', 'resources', 'notes'],
+  scripts: ['https://cdn.polyfill.io/v2/polyfill.min.js'],
   styles: ['default', '/css/theme.css'],
 });
 


### PR DESCRIPTION
Uses polyfill.io to sort out any polyfills that are needed to keep things from crashing in IE11.

Fix for #261