### PR TITLE
Adds ability to show a popup on search

### DIFF
--- a/components/web-components/map/README.md
+++ b/components/web-components/map/README.md
@@ -29,6 +29,10 @@ to “Address search”
 **address-search-placeholder**: String to use as the placeholder in the address
 search box (if visible). Defaults to “Search for an address…”
 
+**address-search-popup-layer-uid**: If provided, clicking on the search result
+markers from an address search will open this layer’s popup. If there’s only one
+search result, the popup will be opened automatically.
+
 **basemap-url**: URL for an ArcGIS tiled layer basemap. Default to our custom
 City of Boston basemap, layered over a generic Esri basemap.
 
@@ -46,6 +50,8 @@ These elements are added as children of `<cob-map>` to include layers of geo
 features on the map.
 
 ### Attributes
+
+**uid**: Identifier string for the layer. Must be unique within the map.
 
 **url**: URL for an ArcGIS feature layer.
 

--- a/web-components/components.d.ts
+++ b/web-components/components.d.ts
@@ -79,6 +79,7 @@ declare global {
       iconSrc?: string;
       label?: string;
       popupTemplate?: string;
+      uid?: string;
       url?: string;
     }
   }
@@ -111,6 +112,7 @@ declare global {
     export interface CobMapAttributes extends HTMLAttributes {
       addressSearchHeading?: string;
       addressSearchPlaceholder?: string;
+      addressSearchPopupLayerUid?: string | null;
       basemapUrl?: string;
       heading?: string;
       latitude?: number;

--- a/web-components/html/city-council.html
+++ b/web-components/html/city-council.html
@@ -31,14 +31,15 @@
 
     <cob-map id="map"
       style="height: 600px"
-      latitude="42.347316"
-      longitude="-71.065227"
+      latitude="42.31667"
+      longitude="-71.13441"
       zoom="12"
       show-zoom-control
       show-legend
       show-address-search
       address-search-heading=""
       address-search-placeholder="Search for your address…"
+      address-search-popup-layer-uid="city-council-districts"
       heading="City Councilor Look-Up">
       <div slot="instructions"
         class="t--info">
@@ -49,10 +50,9 @@
           To see all City Council members, including at-large councilors, visit the
           <a href="https://www.boston.gov/departments/city-council#city-council-members">City Council page</a>.
         </p>
-
       </div>
-      <cob-map-esri-layer url="https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/City_Council_Districts/FeatureServer/0"
-    
+      <cob-map-esri-layer uid="city-council-districts"
+        url="https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/City_Council_Districts/FeatureServer/0"
         color="#0C2639"
         hover-color="#FB4D42"
         label="Boston City Council Districts"

--- a/web-components/map-esri-layer/map-esri-layer.tsx
+++ b/web-components/map-esri-layer/map-esri-layer.tsx
@@ -8,6 +8,7 @@ import { LayerConfig } from '../map/map';
 export class CobMapEsriLayer {
   @Element() el: HTMLElement;
 
+  @Prop() uid: string = '';
   @Prop() url: string;
   @Prop() label: string;
   @Prop() color: string = '';
@@ -37,6 +38,7 @@ export class CobMapEsriLayer {
     const popupScript = this.el.querySelector('script[slot=popup]');
 
     const config: LayerConfig = {
+      uid: this.uid,
       url: this.url,
       label: this.label,
       color: this.color,

--- a/web-components/viz/viz.tsx
+++ b/web-components/viz/viz.tsx
@@ -81,7 +81,7 @@ export interface MapConfig {
   searchForAddress: boolean;
   zoomToAddress: boolean;
   placeholderText?: string | null;
-  showDataLayer: string;
+  addressSearchPopupDataSourceUid: string;
 }
 
 @Component({
@@ -176,6 +176,7 @@ export class CobViz {
             showZoomControl={map.showZoomControl}
             showAddressSearch={map.searchForAddress}
             addressSearchPlaceholder={map.placeholderText}
+            addressSearchPopupLayerUid={map.addressSearchPopupDataSourceUid}
             {...this.getMapProps()}
           >
             {config.description && (


### PR DESCRIPTION
Adds a address-search-popup-layer-uid attribute to <cob-map> that will
bind address search result markers to that layer’s popup. If there’s
only one search result (usually the result of using the autocomplete
menu) then that popup is shown automatically.

Closes #256