### PR TITLE
Adds coverage for a Hub header

### DIFF
--- a/components/base/logo/logo.hbs
+++ b/components/base/logo/logo.hbs
@@ -1,6 +1,6 @@
 <div class="lo">
   <a href="#" class="lo-l">
-    <img src="/images/public/logo.svg" alt="City of Boston" class="lo-i" />
+    <img src="{{#if hub_logo}}/images/hub/logo.svg{{else}}/images/public/logo.svg{{/if}}" alt="City of Boston" class="lo-i" />
     {{#if show_mayor}}
       <span class="lo-t">Mayor Martin J. Walsh</span>
     {{/if}}

--- a/components/base/nav/nav.hbs
+++ b/components/base/nav/nav.hbs
@@ -1,9 +1,11 @@
 <nav class="nv-h">
   <ul class="nv-h-l">
     {{#each links as |link|}}
-      <li class="nv-h-l-i"><a href="{{ link.href }}" title="{{ link.name }}" class="nv-h-l-a">{{ link.name }}</a></li>
+      <li class="nv-h-l-i">
+        <a href="{{ link.href }}" title="{{ link.name }}" class="nv-h-l-a{{#if always_show}} nv-h-l-a--k{{/if}}">{{ link.name }}</a>
+      </li>
     {{/each}}
-    <li class="tr nv-h-l-i">
+    <li class="tr nv-h-l-i tr--visible">
       <a href="#translate" title="Translate" class="nv-h-l-a nv-h-l-a--k--s tr-link">Translate</a>
       <ul class="tr-dd">
         <li><span class="notranslate tr-dd-link tr-dd-link--message">Loading...</span></li>

--- a/components/blocks/header/header.config.yml
+++ b/components/blocks/header/header.config.yml
@@ -11,3 +11,14 @@ context:
       href: https://boston.gov/pay-and-apply
     - name: Feedback
       href: https://boston.gov/feedback
+variants:
+  - name: Hub
+    preview: '@hub'
+    context:
+      show_mayor: false
+      hub_logo: true
+      links:
+      - name: Login
+        href: https://boston.gov/public-notices
+        always_show: true
+

--- a/components/web-components/map/map.hbs
+++ b/components/web-components/map/map.hbs
@@ -23,9 +23,6 @@
       <a href="\{{Bio}}" class="btn btn--b btn--100 btn--sm">Visit webpage<span class="a11y--h"> of {{Councillor}}</span></a>
     </script>
   </cob-map-esri-layer>
-  <cob-map-esri-layer url="https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/Ownership/FeatureServer/0"
-    color="#e1453b"
-    label="Snow Emergency Restricted Parking"></cob-map-esri-layer>
   <cob-map-esri-layer url="https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/SnowParking/FeatureServer/0"
     icon-src="/images/global/icons/mapping/parking.svg"{{#if cluster_icons}}
     cluster-icons{{/if}}

--- a/fractal.js
+++ b/fractal.js
@@ -105,7 +105,7 @@ const mandelbrot = require('@frctl/mandelbrot');
 const fleetTheme = mandelbrot({
   skin: 'blue',
   panels: ['html', 'info', 'resources', 'notes'],
-  scripts: ['https://cdn.polyfill.io/v2/polyfill.min.js'],
+  scripts: ['https://cdn.polyfill.io/v2/polyfill.min.js', 'default'],
   styles: ['default', '/css/theme.css'],
 });
 


### PR DESCRIPTION
Also includes translate link and header links that don’t disappear
at lower breakpoints.

Fixes Mandelbrot scripts that were broken by including the polyfill
script, which Mandelbrot interpreted as a "replace."

And, removes the second vector layer from the web components, which
causes flakiness in Percy due to #249.

Fixes #269

Test-only changes, no need for browser testing.