### PR TITLE
Closes the maps mobile menu on successful search

### DIFF
--- a/web-components/map/map.tsx
+++ b/web-components/map/map.tsx
@@ -236,6 +236,12 @@ export class CobMap {
   }
 
   onAddressSearchResults(data) {
+    if (data.results.length) {
+      // If we're on mobile, the overlay was open to show the address search
+      // field. We close it to keep it from obscuring the results.
+      this.el.openOverlay = false;
+    }
+
     this.addressSearchResultsFeatures.clearLayers();
 
     const markers: LeafletMarker[] = [];


### PR DESCRIPTION
If the address search returns results, we want to close the address
search dropdown on mobile so that it doesn’t obscure anything.

Fixes #270