### PR TITLE
Fixes zIndex stacking for maps legend

### DIFF
--- a/web-components/map/map.css
+++ b/web-components/map/map.css
@@ -66,6 +66,10 @@ cob-map .geocoder-control-suggestions {
   left: 0;
   overflow: auto;
   display: none;
+  
+  /* ensures this stacks above any sub-1 opacity elements, such as appear in the
+  legend. */
+  z-index: 1;
 
   border: none !important;
   border-radius: 0;


### PR DESCRIPTION
Partial opacity on the legend was causing it to appear higher in the
stacking order than the address search dropdown.

Fixes #271