### PR TITLE
Upgrades to Stencil 0.7.6 for Edge fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -131,9 +131,9 @@
       }
     },
     "@stencil/core": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-0.7.5.tgz",
-      "integrity": "sha512-cGIL1y3q9xEDYFowufG0ddYhMcx6Q78VdrUFiWPSXfcFa757wAInwsgBBzvb9hg0p7SKW2IIc57VTn0hWiP+YA==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-0.7.6.tgz",
+      "integrity": "sha512-p5EkT7rJdcRD297CjS3/waanIEl6t6Yr+jvTE/srfXIMjZDrNRBIXuBFph8y2FJTnbjNOoK39AuPyq0pozo9/w==",
       "requires": {
         "chokidar": "2.0.1",
         "jsdom": "11.5.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@frctl/fractal": "^1.1.4",
-    "@stencil/core": "^0.7.5",
+    "@stencil/core": "^0.7.6",
     "@types/geojson": "^7946.0.1",
     "@types/jest": "^22.1.1",
     "@types/leaflet": "^1.2.5",

--- a/web-components/components.d.ts
+++ b/web-components/components.d.ts
@@ -33,23 +33,23 @@ declare global {
     new (): HTMLCobContactFormElement;
   };
   interface HTMLElementTagNameMap {
-    "cob-contact-form": HTMLCobContactFormElement;
+    'cob-contact-form': HTMLCobContactFormElement;
   }
   interface ElementTagNameMap {
-    "cob-contact-form": HTMLCobContactFormElement;
+    'cob-contact-form': HTMLCobContactFormElement;
   }
   namespace JSX {
     interface IntrinsicElements {
-      "cob-contact-form": JSXElements.CobContactFormAttributes;
+      'cob-contact-form': JSXElements.CobContactFormAttributes;
     }
   }
   namespace JSXElements {
     export interface CobContactFormAttributes extends HTMLAttributes {
-      action?: string;
-      defaultSubject?: string;
-      to?: string;
-      token?: string;
-      visible?: boolean;
+      'action'?: string;
+      'defaultSubject'?: string;
+      'to'?: string;
+      'token'?: string;
+      'visible'?: boolean;
       
     }
   }
@@ -68,28 +68,28 @@ declare global {
     new (): HTMLCobMapEsriLayerElement;
   };
   interface HTMLElementTagNameMap {
-    "cob-map-esri-layer": HTMLCobMapEsriLayerElement;
+    'cob-map-esri-layer': HTMLCobMapEsriLayerElement;
   }
   interface ElementTagNameMap {
-    "cob-map-esri-layer": HTMLCobMapEsriLayerElement;
+    'cob-map-esri-layer': HTMLCobMapEsriLayerElement;
   }
   namespace JSX {
     interface IntrinsicElements {
-      "cob-map-esri-layer": JSXElements.CobMapEsriLayerAttributes;
+      'cob-map-esri-layer': JSXElements.CobMapEsriLayerAttributes;
     }
   }
   namespace JSXElements {
     export interface CobMapEsriLayerAttributes extends HTMLAttributes {
-      clusterIcons?: boolean;
-      color?: string;
-      fill?: boolean;
-      hoverColor?: string;
-      iconSrc?: string;
-      label?: string;
-      popupTemplate?: string;
-      uid?: string;
-      url?: string;
-      onCobMapEsriLayerConfig?: (event: CustomEvent) => void;
+      'clusterIcons'?: boolean;
+      'color'?: string;
+      'fill'?: boolean;
+      'hoverColor'?: string;
+      'iconSrc'?: string;
+      'label'?: string;
+      'popupTemplate'?: string;
+      'uid'?: string;
+      'url'?: string;
+      'onCobMapEsriLayerConfig'?: (event: CustomEvent) => void;
     }
   }
 }
@@ -107,30 +107,30 @@ declare global {
     new (): HTMLCobMapElement;
   };
   interface HTMLElementTagNameMap {
-    "cob-map": HTMLCobMapElement;
+    'cob-map': HTMLCobMapElement;
   }
   interface ElementTagNameMap {
-    "cob-map": HTMLCobMapElement;
+    'cob-map': HTMLCobMapElement;
   }
   namespace JSX {
     interface IntrinsicElements {
-      "cob-map": JSXElements.CobMapAttributes;
+      'cob-map': JSXElements.CobMapAttributes;
     }
   }
   namespace JSXElements {
     export interface CobMapAttributes extends HTMLAttributes {
-      addressSearchHeading?: string;
-      addressSearchPlaceholder?: string;
-      addressSearchPopupLayerUid?: string | null;
-      basemapUrl?: string;
-      heading?: string;
-      latitude?: number;
-      longitude?: number;
-      openOverlay?: boolean;
-      showAddressSearch?: boolean;
-      showLegend?: boolean;
-      showZoomControl?: boolean;
-      zoom?: number;
+      'addressSearchHeading'?: string;
+      'addressSearchPlaceholder'?: string;
+      'addressSearchPopupLayerUid'?: string | null;
+      'basemapUrl'?: string;
+      'heading'?: string;
+      'latitude'?: number;
+      'longitude'?: number;
+      'openOverlay'?: boolean;
+      'showAddressSearch'?: boolean;
+      'showLegend'?: boolean;
+      'showZoomControl'?: boolean;
+      'zoom'?: number;
       
     }
   }
@@ -149,19 +149,19 @@ declare global {
     new (): HTMLCobVizElement;
   };
   interface HTMLElementTagNameMap {
-    "cob-viz": HTMLCobVizElement;
+    'cob-viz': HTMLCobVizElement;
   }
   interface ElementTagNameMap {
-    "cob-viz": HTMLCobVizElement;
+    'cob-viz': HTMLCobVizElement;
   }
   namespace JSX {
     interface IntrinsicElements {
-      "cob-viz": JSXElements.CobVizAttributes;
+      'cob-viz': JSXElements.CobVizAttributes;
     }
   }
   namespace JSXElements {
     export interface CobVizAttributes extends HTMLAttributes {
-      config?: string;
+      'config'?: string;
       
     }
   }


### PR DESCRIPTION
Ran TestCafe in Chrome, Firefox, Safari, IE11, and Edge.