### PR TITLE
Adds new fixture rather than navigate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ branches:
   only:
   - develop
   - production
-before_install:
-- rvm install 2.4.0
 install:
 - npm install
 - gem install percy-cli

--- a/web-components/components.d.ts
+++ b/web-components/components.d.ts
@@ -33,23 +33,23 @@ declare global {
     new (): HTMLCobContactFormElement;
   };
   interface HTMLElementTagNameMap {
-    "cob-contact-form": HTMLCobContactFormElement;
+    'cob-contact-form': HTMLCobContactFormElement;
   }
   interface ElementTagNameMap {
-    "cob-contact-form": HTMLCobContactFormElement;
+    'cob-contact-form': HTMLCobContactFormElement;
   }
   namespace JSX {
     interface IntrinsicElements {
-      "cob-contact-form": JSXElements.CobContactFormAttributes;
+      'cob-contact-form': JSXElements.CobContactFormAttributes;
     }
   }
   namespace JSXElements {
     export interface CobContactFormAttributes extends HTMLAttributes {
-      action?: string;
-      defaultSubject?: string;
-      to?: string;
-      token?: string;
-      visible?: boolean;
+      'action'?: string;
+      'defaultSubject'?: string;
+      'to'?: string;
+      'token'?: string;
+      'visible'?: boolean;
       
     }
   }
@@ -68,28 +68,28 @@ declare global {
     new (): HTMLCobMapEsriLayerElement;
   };
   interface HTMLElementTagNameMap {
-    "cob-map-esri-layer": HTMLCobMapEsriLayerElement;
+    'cob-map-esri-layer': HTMLCobMapEsriLayerElement;
   }
   interface ElementTagNameMap {
-    "cob-map-esri-layer": HTMLCobMapEsriLayerElement;
+    'cob-map-esri-layer': HTMLCobMapEsriLayerElement;
   }
   namespace JSX {
     interface IntrinsicElements {
-      "cob-map-esri-layer": JSXElements.CobMapEsriLayerAttributes;
+      'cob-map-esri-layer': JSXElements.CobMapEsriLayerAttributes;
     }
   }
   namespace JSXElements {
     export interface CobMapEsriLayerAttributes extends HTMLAttributes {
-      clusterIcons?: boolean;
-      color?: string;
-      fill?: boolean;
-      hoverColor?: string;
-      iconSrc?: string;
-      label?: string;
-      popupTemplate?: string;
-      uid?: string;
-      url?: string;
-      onCobMapEsriLayerConfig?: (event: CustomEvent) => void;
+      'clusterIcons'?: boolean;
+      'color'?: string;
+      'fill'?: boolean;
+      'hoverColor'?: string;
+      'iconSrc'?: string;
+      'label'?: string;
+      'popupTemplate'?: string;
+      'uid'?: string;
+      'url'?: string;
+      'onCobMapEsriLayerConfig'?: (event: CustomEvent) => void;
     }
   }
 }
@@ -107,30 +107,30 @@ declare global {
     new (): HTMLCobMapElement;
   };
   interface HTMLElementTagNameMap {
-    "cob-map": HTMLCobMapElement;
+    'cob-map': HTMLCobMapElement;
   }
   interface ElementTagNameMap {
-    "cob-map": HTMLCobMapElement;
+    'cob-map': HTMLCobMapElement;
   }
   namespace JSX {
     interface IntrinsicElements {
-      "cob-map": JSXElements.CobMapAttributes;
+      'cob-map': JSXElements.CobMapAttributes;
     }
   }
   namespace JSXElements {
     export interface CobMapAttributes extends HTMLAttributes {
-      addressSearchHeading?: string;
-      addressSearchPlaceholder?: string;
-      addressSearchPopupLayerUid?: string | null;
-      basemapUrl?: string;
-      heading?: string;
-      latitude?: number;
-      longitude?: number;
-      openOverlay?: boolean;
-      showAddressSearch?: boolean;
-      showLegend?: boolean;
-      showZoomControl?: boolean;
-      zoom?: number;
+      'addressSearchHeading'?: string;
+      'addressSearchPlaceholder'?: string;
+      'addressSearchPopupLayerUid'?: string | null;
+      'basemapUrl'?: string;
+      'heading'?: string;
+      'latitude'?: number;
+      'longitude'?: number;
+      'openOverlay'?: boolean;
+      'showAddressSearch'?: boolean;
+      'showLegend'?: boolean;
+      'showZoomControl'?: boolean;
+      'zoom'?: number;
       
     }
   }
@@ -149,19 +149,19 @@ declare global {
     new (): HTMLCobVizElement;
   };
   interface HTMLElementTagNameMap {
-    "cob-viz": HTMLCobVizElement;
+    'cob-viz': HTMLCobVizElement;
   }
   interface ElementTagNameMap {
-    "cob-viz": HTMLCobVizElement;
+    'cob-viz': HTMLCobVizElement;
   }
   namespace JSX {
     interface IntrinsicElements {
-      "cob-viz": JSXElements.CobVizAttributes;
+      'cob-viz': JSXElements.CobVizAttributes;
     }
   }
   namespace JSXElements {
     export interface CobVizAttributes extends HTMLAttributes {
-      config?: string;
+      'config'?: string;
       
     }
   }


### PR DESCRIPTION
Hopeful change to de-flake IE tests on Browserstack.

Also removes rvm install from .travis.yml to use system-default Ruby to
install the Percy tool.

Re-build w/ latest Stencil affected components.d.ts.