### PR TITLE
Changes person card CSS to have consistent height

### DIFF
--- a/components/blocks/grid-person-cards/grid-person-cards.config.yml
+++ b/components/blocks/grid-person-cards/grid-person-cards.config.yml
@@ -9,7 +9,7 @@ context:
     title: City Government
     contact: false
   people:
-    - name: Mayor Martin J. Walsh
+    - name: Martin J. Walsh
       position: Mayor
       image: https://www.boston.gov/sites/default/files/mayor-walsh2.jpg
       contact: mailto:mayor@boston.gov
@@ -21,8 +21,8 @@ context:
       contact: mailto:mayor@boston.gov
       url: https://www.boston.gov/mayor
       grid: g--1 g--3--sl
-    - name: Mayor Martin J. Walsh
-      position: Mayor
+    - name: Martin J. Walsh
+      position: Mayor of the City of Boston in the Commonwealth of Massachusetts.
       image: https://www.boston.gov/sites/default/files/mayor-walsh2.jpg
       contact: mailto:mayor@boston.gov
       url: https://www.boston.gov/mayor

--- a/stylesheets/components/card/_person.styl
+++ b/stylesheets/components/card/_person.styl
@@ -16,7 +16,7 @@
 
 .cdp
   display: flex
-  flex-wrap: wrap
+  flex-direction: column
 
   &-a
     line-height: $line-height-000
@@ -27,6 +27,7 @@
 
   &-l
     display: flex
+    flex-grow: 1
     align-items: center
     background-color: $grey-000
     text-align: left


### PR DESCRIPTION
Prevents the bottom button from increasing in size if the top doesn't
have enough content.

Closes #211
Fixes CityOfBoston/boston.gov#960