### PR TITLE
Changes Percy to not diff against "master"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ install:
 before_script:
 - export BROWSERSTACK_PROJECT_NAME=$TRAVIS_REPO_SLUG
 - export BROWSERSTACK_BUILD_ID=$TRAVIS_BUILD_NUMBER
+# Percy automatically uses branches from PRs. This is so for both develop and
+# production we don't make diffs against master, which is unused.
+- export PERCY_TARGET_BRANCH=$TRAVIS_BRANCH
 script:
 - npm run build
 - npm run jest.ci

--- a/travis/percy.sh
+++ b/travis/percy.sh
@@ -1,6 +1,3 @@
 #!/bin/bash
 
-if [ "$TRAVIS_BRANCH" != "production" ]
-then
-  percy snapshot public --snapshots_regex="(components\/preview.).*\.html$" --enable_javascript --trace --widths "375,1024,1280"
-fi
+percy snapshot public --snapshots_regex="(components\/preview.).*\.html$" --enable_javascript --trace --widths "375,1024,1280"


### PR DESCRIPTION
For both develop and production branches, treat the latest versions of
those branches as canonical.

Also reinstates running against the production branch, so that prod push
PRs will get an accurate update of what will change with the release.