### PR TITLE
Changes zoom/lat/lng to be mutable properties

### DIFF
--- a/components/web-components/map/__tests__/map-model.ts
+++ b/components/web-components/map/__tests__/map-model.ts
@@ -1,10 +1,24 @@
 import { Selector } from 'testcafe';
 import { readyComponentSelector } from '../../../../lib/testcafe/helpers';
 
+interface MapSelector extends Selector {
+  zoom: Promise<any>;
+  latitude: Promise<any>;
+  longitude: Promise<any>;
+}
+
 /* PageModel class to encapsulate Map component functionality. */
 export default class MapModel {
-  root = Selector(readyComponentSelector('cob-map'));
+  root = Selector(readyComponentSelector('cob-map')).addCustomDOMProperties({
+    // TODO(finh): Type this with the Stencil components types once we can
+    // provide a custom tsconfig.json to TestCafe to get it to recognize .tsx
+    // files. See DevExpress/testcafe#1845
+    zoom: (el: any) => el.zoom,
+    latitude: (el: any) => el.latitude,
+    longitude: (el: any) => el.longitude,
+  }) as MapSelector;
   leafletPopup = this.root.find('.leaflet-popup');
+  zoomInButton = this.root.find('.leaflet-control-zoom-in');
 
   interactivePolygonsByColor(color: string) {
     return this.root.find(

--- a/components/web-components/map/__tests__/map.testcafe.ts
+++ b/components/web-components/map/__tests__/map.testcafe.ts
@@ -103,3 +103,12 @@ test('Clicking parking marker shows popup', async t => {
     'You must show proof of your residency in the Back Bay, South End, or Bay Village.'
   );
 });
+
+test('Zooming changes the properties of the map', async t => {
+  // Changes to zoom and position should be reflected back out as properties
+  // (and potentially attributes). We test zoom because it's easiest (button
+  // click) but assume the code path for lat/lng is the same.
+  await t.expect(map.root.zoom).eql(12);
+  await t.click(map.zoomInButton);
+  await t.expect(map.root.zoom).eql(13);
+});

--- a/web-components/map/map.tsx
+++ b/web-components/map/map.tsx
@@ -104,19 +104,22 @@ export class CobMap {
    * Position to center the map on to start. Will be updated as the map is moved
    * by the user. Changes to this will move the map.
    */
-  @Prop() latitude: number = 42.357004;
+  @Prop({ mutable: true })
+  latitude: number = 42.357004;
 
   /**
    * Position to center the map on to start. Will be updated as the map is moved
    * by the user. Changes to this will move the map.
    */
-  @Prop() longitude: number = -71.062309;
+  @Prop({ mutable: true })
+  longitude: number = -71.062309;
 
   /**
    * Zoom level for the map. Will be updated as the map is zoomed. Changes to
    * this will zoom the map.
    */
-  @Prop() zoom: number = 14;
+  @Prop({ mutable: true })
+  zoom: number = 14;
 
   /**
    * Boolean attribute for whether to show zoom buttons in the bottom right of
@@ -163,7 +166,8 @@ export class CobMap {
    * Test attribute to make the overlay open automatically at mobile widths.
    * Only used so that we can take Percy screenshots of the overlay.
    */
-  @Prop() openOverlay: boolean = false;
+  @Prop({ mutable: true })
+  openOverlay: boolean = false;
 
   // Used to keep our IDs distinct on the page
   idSuffix = Math.random()
@@ -298,7 +302,7 @@ export class CobMap {
     if (data.results.length) {
       // If we're on mobile, the overlay was open to show the address search
       // field. We close it to keep it from obscuring the results.
-      this.el.openOverlay = false;
+      this.openOverlay = false;
     }
 
     this.addressSearchResultsFeatures.clearLayers();
@@ -529,18 +533,19 @@ export class CobMap {
 
   // Handler to keep our attributes up-to-date with map movements from the UI.
   handleMapPositionChangeEnd() {
+    // Keeps us from moving the map in response to these changes.
     this.mapMoveInProgress = true;
 
     const { lat, lng } = this.map.getCenter();
-    this.el.setAttribute('latitude', lat.toString());
-    this.el.setAttribute('longitude', lng.toString());
-    this.el.setAttribute('zoom', this.map.getZoom().toString());
+    this.latitude = lat;
+    this.longitude = lng;
+    this.zoom = this.map.getZoom();
 
     this.mapMoveInProgress = false;
   }
 
   handleLegendLabelMouseClick(ev: MouseEvent) {
-    this.el.openOverlay = !this.el.openOverlay;
+    this.openOverlay = !this.openOverlay;
     ev.stopPropagation();
     ev.preventDefault();
   }


### PR DESCRIPTION
Fixes #284. Using this.el.setAttribute was good for reflecting the
attributes back to the DOM but in polyfilled browsers caused an infinite
feedback loop where the attribute change happened outside of the
"mapMoveInProgress" guard.

Also adds test coverage for map zooming in the UI being reflected in the
element's properties.