### PR TITLE
Changes the Stencil namespace to "FleetComponents"

### DIFF
--- a/components/_preview.hbs
+++ b/components/_preview.hbs
@@ -16,7 +16,7 @@
 
   <!-- web components script must come first, or Stencil 0.7.2 replaces the
   wrong tag -->
-  <script src="{{path '/web-components/all.js'}}"></script>
+  <script src="{{path '/web-components/fleetcomponents.js'}}"></script>
   <script src="{{path '/scripts/all.js'}}"></script>
 </body>
 </html>

--- a/stencil.config.js
+++ b/stencil.config.js
@@ -1,5 +1,5 @@
 exports.config = {
-  namespace: 'all',
+  namespace: 'FleetComponents',
   buildEs5: true,
 
   srcDir: 'web-components',

--- a/web-components/html/city-council-viz.html
+++ b/web-components/html/city-council-viz.html
@@ -75,7 +75,7 @@
     </cob-viz>
   </div>
 
-  <script src="/web-components/all.js"></script>
+  <script src="/web-components/fleetcomponents.js"></script>
 </body>
 
 </html>

--- a/web-components/html/city-council.html
+++ b/web-components/html/city-council.html
@@ -72,7 +72,7 @@
     </cob-map>
   </div>
 
-  <script src="/web-components/all.js"></script>
+  <script src="/web-components/fleetcomponents.js"></script>
 </body>
 
 </html>

--- a/web-components/html/index.html
+++ b/web-components/html/index.html
@@ -17,7 +17,7 @@
     <link media="all" rel="stylesheet" href="/css/ie.css">
   <![endif]-->
 
-  <script src="/web-components/all.js"></script>
+  <script src="/web-components/fleetcomponents.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
The old name of "all" was too likely to be a naming conflict with other
code. For example, the Stencil loader defines a global object with the
namespace name. "FleetComponents" is a better choice for that than
"all".

Because the sync to S3 is additive, we can deploy this and then switch
the sites that link to the web components over later.