### PR TITLE
Remove dotted line from Scripts sidebar.

### DIFF
--- a/legacy/public.styl
+++ b/legacy/public.styl
@@ -7654,11 +7654,6 @@ a.item-link {
     margin-top: 39px;
     margin-top: 2.16667rem
 }
-.node-script-page .contact-info {
-    margin-bottom: 30px;
-    padding-bottom: 30px;
-    border-bottom: 1px dashed #e0e0e0
-}
 .node-script-page .contact-info p {
     margin-bottom: 16px
 }


### PR DESCRIPTION
Removes the dotted line and extra space at the bottom of the right sidebar on Scripts pages.

Fixes https://github.com/CityOfBoston/boston.gov/issues/1097

**Note:** Need to pass the `--no-verify` flag b/c failing tests related to CobViz