### PR TITLE
Fix for BrowserStack 403s

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5629,7 +5629,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-      "optional": true,
       "requires": {
         "nan": "2.8.0",
         "node-pre-gyp": "0.6.39"
@@ -5637,13 +5636,11 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ajv": {
           "version": "4.11.8",
           "bundled": true,
-          "optional": true,
           "requires": {
             "co": "4.6.0",
             "json-stable-stringify": "1.0.1"
@@ -5655,13 +5652,11 @@
         },
         "aproba": {
           "version": "1.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "delegates": "1.0.0",
             "readable-stream": "2.2.9"
@@ -5669,28 +5664,23 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aws4": {
           "version": "1.6.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "balanced-match": {
           "version": "0.4.2",
@@ -5732,13 +5722,11 @@
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "co": {
           "version": "4.6.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
@@ -5773,30 +5761,26 @@
         "dashdash": {
           "version": "1.14.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
         "debug": {
           "version": "2.6.8",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "deep-extend": {
           "version": "0.4.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "delayed-stream": {
           "version": "1.0.0",
@@ -5804,13 +5788,11 @@
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "detect-libc": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
@@ -5822,8 +5804,7 @@
         },
         "extend": {
           "version": "3.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "extsprintf": {
           "version": "1.0.2",
@@ -5831,13 +5812,11 @@
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "form-data": {
           "version": "2.1.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.5",
@@ -5861,7 +5840,6 @@
         "fstream-ignore": {
           "version": "1.0.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "fstream": "1.0.11",
             "inherits": "2.0.3",
@@ -5871,7 +5849,6 @@
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "aproba": "1.1.1",
             "console-control-strings": "1.1.0",
@@ -5886,15 +5863,13 @@
         "getpass": {
           "version": "0.1.7",
           "bundled": true,
-          "optional": true,
           "requires": {
             "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -5916,13 +5891,11 @@
         },
         "har-schema": {
           "version": "1.0.5",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "har-validator": {
           "version": "4.2.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ajv": "4.11.8",
             "har-schema": "1.0.5"
@@ -5930,8 +5903,7 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "hawk": {
           "version": "3.1.3",
@@ -5950,7 +5922,6 @@
         "http-signature": {
           "version": "1.1.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "assert-plus": "0.2.0",
             "jsprim": "1.4.0",
@@ -5971,8 +5942,7 @@
         },
         "ini": {
           "version": "1.3.4",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -5983,8 +5953,7 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "isarray": {
           "version": "1.0.0",
@@ -5992,8 +5961,7 @@
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "jodid25519": {
           "version": "1.0.2",
@@ -6010,31 +5978,26 @@
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "jsonify": "0.0.0"
           }
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "jsprim": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.0.2",
@@ -6044,8 +6007,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -6080,13 +6042,11 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "node-pre-gyp": {
           "version": "0.6.39",
           "bundled": true,
-          "optional": true,
           "requires": {
             "detect-libc": "1.0.2",
             "hawk": "3.1.3",
@@ -6104,7 +6064,6 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "abbrev": "1.1.0",
             "osenv": "0.1.4"
@@ -6113,7 +6072,6 @@
         "npmlog": {
           "version": "4.1.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
             "console-control-strings": "1.1.0",
@@ -6127,13 +6085,11 @@
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "once": {
           "version": "1.4.0",
@@ -6144,18 +6100,15 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "osenv": {
           "version": "0.1.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
@@ -6167,8 +6120,7 @@
         },
         "performance-now": {
           "version": "0.2.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
@@ -6176,18 +6128,15 @@
         },
         "punycode": {
           "version": "1.4.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "qs": {
           "version": "6.4.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "rc": {
           "version": "1.2.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "deep-extend": "0.4.2",
             "ini": "1.3.4",
@@ -6197,8 +6146,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -6218,7 +6166,6 @@
         "request": {
           "version": "2.81.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "aws-sign2": "0.6.0",
             "aws4": "1.6.0",
@@ -6257,18 +6204,15 @@
         },
         "semver": {
           "version": "5.3.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "sntp": {
           "version": "1.0.9",
@@ -6280,7 +6224,6 @@
         "sshpk": {
           "version": "1.13.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "asn1": "0.2.3",
             "assert-plus": "1.0.0",
@@ -6295,8 +6238,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -6318,8 +6260,7 @@
         },
         "stringstream": {
           "version": "0.0.5",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -6330,8 +6271,7 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "tar": {
           "version": "2.2.1",
@@ -6345,7 +6285,6 @@
         "tar-pack": {
           "version": "3.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "debug": "2.6.8",
             "fstream": "1.0.11",
@@ -6360,7 +6299,6 @@
         "tough-cookie": {
           "version": "2.3.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "punycode": "1.4.1"
           }
@@ -6368,7 +6306,6 @@
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "5.0.1"
           }
@@ -6380,8 +6317,7 @@
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "util-deprecate": {
           "version": "1.0.2",
@@ -6389,13 +6325,11 @@
         },
         "uuid": {
           "version": "3.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "verror": {
           "version": "1.3.6",
           "bundled": true,
-          "optional": true,
           "requires": {
             "extsprintf": "1.0.2"
           }
@@ -6403,7 +6337,6 @@
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "string-width": "1.0.2"
           }
@@ -11352,8 +11285,7 @@
     "nan": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
-      "optional": true
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
     },
     "nanoid": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "testcafe": "npm run build && npm run testcafe.local",
     "testcafe.local": "cross-env TEST_SERVER_URL=http://localhost:3035/ testcafe -a 'http-server -r public -p 3035' -c 3 chrome:headless components/**/*.testcafe.*",
     "testcafe.dev": "testcafe-live remote components/**/*.testcafe.*",
-    "testcafe.ci": "cross-env TEST_SERVER_URL=http://localhost:3035/ testcafe -a 'http-server -r public -p 3035' 'browserstack:edge,browserstack:ie@11.0,browserstack:safari,browserstack:chrome,browserstack:firefox' components/**/*.testcafe.*",
+    "testcafe.ci": "cross-env BROWSERSTACK_USE_AUTOMATE=1 TEST_SERVER_URL=http://localhost:3035/ testcafe -a 'http-server -r public -p 3035' 'browserstack:edge,browserstack:ie@11.0,browserstack:safari,browserstack:chrome,browserstack:firefox' components/**/*.testcafe.*",
     "precommit": "lint-staged",
-    "prepush": "npm run test"
+    "prepush": "jest --clearCache && npm run test"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
Switches us to use the newer APIs.

Also adds a jest --clearCache in prepush to avoid strange errors when
dependencies are updated.