### PR TITLE
Adds "Canceled" to Event summary pages when canceled + slight revisions.

### DIFF
--- a/stylesheets/base/global/_text.styl
+++ b/stylesheets/base/global/_text.styl
@@ -128,6 +128,9 @@
     font-size: responsive $font-400 $font-500
     font-range: 480px 1440px
 
+  &--s60pct
+    font-size: 60%
+
 // Text-alignment
 .ta
   &-c
@@ -161,3 +164,8 @@
 
   &-n
     text-transform: none
+
+// Text-decorations
+.td
+  &-str
+    text-decoration: line-through


### PR DESCRIPTION
Part of PR for drupal.gov repo PR CityOfBoston/boston.gov#1114
Adds styles for Events which are cancelled.

t--s60pct: sets font-size to be 60% of parent
td--str: sets text-decoration to be strikethrough (existing str theme designed for larger font headings.)

@finneganh