### PR TITLE
Adds css to center tables in drawers in smaller screen widths.

### DIFF
--- a/stylesheets/components/drawers/_drawer.styl
+++ b/stylesheets/components/drawers/_drawer.styl
@@ -94,9 +94,9 @@
       margin-bottom: 0
 
     @media $media-small-max
-      .content
-        padding-left: 0 !important
-        padding-right: 0 !important
+      .paragraphs-item-text-one-column .content
+        padding-left: 0
+        padding-right: 0
 
         .responsive-table
           font-size: 4.5vw

--- a/stylesheets/components/drawers/_drawer.styl
+++ b/stylesheets/components/drawers/_drawer.styl
@@ -93,6 +93,15 @@
     ul:last-child
       margin-bottom: 0
 
+    @media $media-small-max
+      .content
+        padding-left: 0 !important
+        padding-right: 0 !important
+
+        .responsive-table
+          font-size: 4.5vw
+          border: 1px solid black
+
   &-ic
     height: 20px
     width: 26px


### PR DESCRIPTION
Related to boston.gov ticket #302 .
Fixes table centering and overflow issues when displayed in drawer components on smaller screen widths.
@jimafisk 