### PR TITLE
Adds explict "fill" option to map polygons

### DIFF
--- a/components/web-components/map/map.hbs
+++ b/components/web-components/map/map.hbs
@@ -10,7 +10,8 @@
       "polygons": {
         "style": "default",
         "color": "#0c2639",
-        "hoverColor": "#fb4d42"
+        "hoverColor": "#fb4d42",
+        "fill": true
       },
       "popupHtmlTemplate": "<img src=\"\{{Image}}\" class=\"cdp-i\" alt=\"\{{Councilor}}\" style=\"margin-bottom: 1rem\"/>\n          <div class=\"ta-c m-v300\">\n            <div class=\"cdp-t t--sans t--upper m-t200\">\{{Councilor}}</div>\n            <div class=\"cdp-st t--subinfo t--g300\">District \{{DISTRICT}}</div>\n          </div>\n          <a href=\"\{{Bio}}\" class=\"btn btn--b btn--100 btn--sm\">\n            Visit webpage<span class=\"a11y--h\"> of \{{Councillor}}</span>\n          </a>",
       "data": {

--- a/web-components/html/map-editor.html
+++ b/web-components/html/map-editor.html
@@ -12,10 +12,21 @@
   <link rel="stylesheet"
     type="text/css"
     href="/css/public.css" />
+  <link rel="stylesheet"
+    type="text/css"
+    href="/legacy/public.css" />
   <!--<![endif]-->
   <!--[if lt IE 10]>
     <link media="all" rel="stylesheet" href="/css/ie.css">
   <![endif]-->
+
+  <style type="text/css">
+    /* overriding Boston.gov styles */
+    textarea {
+      line-height: 1 !important;
+      font-size: 14px !important; 
+    }
+  </style>
 </head>
 
 <body>

--- a/web-components/map/map.css
+++ b/web-components/map/map.css
@@ -2,6 +2,11 @@ cob-map {
   display: block;
 }
 
+cob-map h3 {
+  /* overriding the italics that Boston.gov puts on h3s */
+  font-style: inherit;
+}
+
 cob-map.leaflet-container a.leaflet-popup-close-button {
   /* By default this is too tight in the corner */
   top: 6px;
@@ -141,6 +146,11 @@ cob-map .cob-map-modal-controls {
   cob-map .cob-address-search-field-container.focused {
     margin-bottom: 40%;
   }
+}
+
+cob-map svg {
+  width: initial;
+  height: initial;
 }
 
 cob-map .geocoder-control-suggestions {

--- a/web-components/map/map.tsx
+++ b/web-components/map/map.tsx
@@ -327,10 +327,14 @@ export class CobMap {
               uid: uid!,
               url: `${data.service!}/${data.layer!}`,
               legendLabel: (legend && legend.label) || '',
-              legendSymbol: (legend && legend.symbol) || null,
+              legendSymbol:
+                (icons && 'icon') ||
+                (polygons && polygons.fill && 'polygon') ||
+                (polygons && 'line') ||
+                null,
               color: polygons ? polygons.color : null,
               hoverColor: polygons ? polygons.hoverColor : null,
-              fill: true,
+              fill: (polygons && polygons.fill) || false,
               iconSrc: icons ? icons.markerUrl : null,
               clusterIcons: (icons && icons.cluster) || false,
               popupTemplate: popupHtmlTemplate,

--- a/web-components/types/viz-1.0.schema.d.ts
+++ b/web-components/types/viz-1.0.schema.d.ts
@@ -77,6 +77,10 @@ export interface VectorStyle {
    * Hex color to use as the stroke color on features when the mouse is hovered over them. If a fill is applied, it will be this color at a semi-transparent opacity.
    */
   hoverColor?: string;
+  /**
+   * If true, fills the polygons with the color at partial opacity.
+   */
+  fill?: boolean;
 }
 export interface ArcGisFeatureService {
   /**
@@ -93,12 +97,6 @@ export interface ArcGisFeatureService {
   layer?: number;
 }
 export interface LegendStyle {
-  /**
-   * * `icon`: Shows the `markerUrl` icon from `icons`.
-   * * `line`: Renders a line with the `color` from the `polygons` configuration.
-   * * `polygon`: Renders a box with the `color` from the `polygons` configuration, with a semitransparent fill.
-   */
-  symbol?: 'icon' | 'line' | 'polygon';
   /**
    * The label to show in the legend for this layer.
    */


### PR DESCRIPTION
Updates to latest JSON schema for maps. Changes polygons to allow both
"fill" and "line" options. Updates legend to base its icon on how the
polygon renders, rather than a separate option.

Also brings the Boston.gov stylesheet into the editor so it's clearer to
see how the map will look on Boston.gov.