### PR TITLE
Adds legend to modal maps display

### DIFF
--- a/components/web-components/map/map.config.yml
+++ b/components/web-components/map/map.config.yml
@@ -38,6 +38,13 @@ variants:
       modal_visible: true
       show_address_search: true
 
+  - name: Modal Overlay Open
+    context:
+      modal: true
+      modal_visible: true
+      show_address_search: true
+      open_overlay: true
+
   - name: Modal Toggle
     context:
       modal: true

--- a/components/web-components/map/map.hbs
+++ b/components/web-components/map/map.hbs
@@ -13,7 +13,7 @@
         "hoverColor": "#fb4d42",
         "fill": true
       },
-      "popupHtmlTemplate": "<img src=\"\{{Image}}\" class=\"cdp-i\" alt=\"\{{Councilor}}\" style=\"margin-bottom: 1rem\"/>\n          <div class=\"ta-c m-v300\">\n            <div class=\"cdp-t t--sans t--upper m-t200\">\{{Councilor}}</div>\n            <div class=\"cdp-st t--subinfo t--g300\">District \{{DISTRICT}}</div>\n          </div>\n          <a href=\"\{{Bio}}\" class=\"btn btn--b btn--100 btn--sm\">\n            Visit webpage<span class=\"a11y--h\"> of \{{Councillor}}</span>\n          </a>",
+      "popupHtmlTemplate": "<img src=\"\{{Image}}\" class=\"cdp-i cdp-i--c\" alt=\"\{{Councilor}}\" style=\"margin-bottom: 1rem\"/>\n          <div class=\"ta-c m-v300\">\n            <div class=\"cdp-t t--sans t--upper m-t200\">\{{Councilor}}</div>\n            <div class=\"cdp-st t--subinfo t--g300\">District \{{DISTRICT}}</div>\n          </div>\n          <a href=\"\{{Bio}}\" class=\"btn btn--b btn--100 btn--sm\">\n            Visit webpage<span class=\"a11y--h\"> of \{{Councillor}}</span>\n          </a>",
       "data": {
         "type": "arcgis",
         "service": "https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/City_Council_Districts/FeatureServer",

--- a/stylesheets/components/card/_person.styl
+++ b/stylesheets/components/card/_person.styl
@@ -69,6 +69,10 @@
       width: 173px
       height: 173px
 
+    // Option for always centering, even on mobile breakpoints
+    &--c
+      margin: 0 auto;
+
 /* Handle theme variations */
 .b--g
   .cdp

--- a/web-components/html/city-council-modal.html
+++ b/web-components/html/city-council-modal.html
@@ -38,7 +38,7 @@
         "color": "#0C2639",
         "hoverColor": "#FB4D42"
       },
-      "popupHtmlTemplate": "<img src=\"{{Image}}\" class=\"cdp-i\" alt=\"{{Councilor}}\" style=\"margin-bottom: 1rem\"/>\n          <div class=\"ta-c m-v300\">\n            <div class=\"cdp-t t--sans t--upper m-t200\">{{Councilor}}</div>\n            <div class=\"cdp-st t--subinfo t--g300\">District {{DISTRICT}}</div>\n          </div>\n          <a href=\"{{Bio}}\" class=\"btn btn--b btn--100 btn--sm\">\n            Visit webpage<span class=\"a11y--h\"> of {{Councillor}}</span>\n          </a>",
+      "popupHtmlTemplate": "<img src=\"{{Image}}\" class=\"cdp-i cdp-i--c\" alt=\"{{Councilor}}\" style=\"margin-bottom: 1rem\"/>\n          <div class=\"ta-c m-v300\">\n            <div class=\"cdp-t t--sans t--upper m-t200\">{{Councilor}}</div>\n            <div class=\"cdp-st t--subinfo t--g300\">District {{DISTRICT}}</div>\n          </div>\n          <a href=\"{{Bio}}\" class=\"btn btn--b btn--100 btn--sm\">\n            Visit webpage<span class=\"a11y--h\"> of {{Councillor}}</span>\n          </a>",
       "data": {
         "type": "arcgis",
         "service": "https://services.arcgis.com/sFnw0xNflSi8J0uh/ArcGIS/rest/services/City_Council_Districts/FeatureServer",

--- a/web-components/html/city-council.html
+++ b/web-components/html/city-council.html
@@ -44,7 +44,7 @@
         "color": "#0C2639",
         "hoverColor": "#FB4D42"
       },
-      "popupHtmlTemplate": "<img src=\"{{Image}}\" class=\"cdp-i\" alt=\"{{Councilor}}\" style=\"margin-bottom: 1rem\"/>\n          <div class=\"ta-c m-v300\">\n            <div class=\"cdp-t t--sans t--upper m-t200\">{{Councilor}}</div>\n            <div class=\"cdp-st t--subinfo t--g300\">District {{DISTRICT}}</div>\n          </div>\n          <a href=\"{{Bio}}\" class=\"btn btn--b btn--100 btn--sm\">\n            Visit webpage<span class=\"a11y--h\"> of {{Councillor}}</span>\n          </a>",
+      "popupHtmlTemplate": "<img src=\"{{Image}}\" class=\"cdp-i cdp-i--c\" alt=\"{{Councilor}}\" style=\"margin-bottom: 1rem\"/>\n          <div class=\"ta-c m-v300\">\n            <div class=\"cdp-t t--sans t--upper m-t200\">{{Councilor}}</div>\n            <div class=\"cdp-st t--subinfo t--g300\">District {{DISTRICT}}</div>\n          </div>\n          <a href=\"{{Bio}}\" class=\"btn btn--b btn--100 btn--sm\">\n            Visit webpage<span class=\"a11y--h\"> of {{Councillor}}</span>\n          </a>",
       "data": {
         "type": "arcgis",
         "service": "https://services.arcgis.com/sFnw0xNflSi8J0uh/ArcGIS/rest/services/City_Council_Districts/FeatureServer",

--- a/web-components/html/map-editor.html
+++ b/web-components/html/map-editor.html
@@ -47,7 +47,7 @@
         "color": "#0C2639",
         "hoverColor": "#FB4D42"
       },
-      "popupHtmlTemplate": "<img src=\"{{Image}}\" class=\"cdp-i\" alt=\"{{Councilor}}\" style=\"margin-bottom: 1rem\"/>\n          <div class=\"ta-c m-v300\">\n            <div class=\"cdp-t t--sans t--upper m-t200\">{{Councilor}}</div>\n            <div class=\"cdp-st t--subinfo t--g300\">District {{DISTRICT}}</div>\n          </div>\n          <a href=\"{{Bio}}\" class=\"btn btn--b btn--100 btn--sm\">\n            Visit webpage<span class=\"a11y--h\"> of {{Councillor}}</span>\n          </a>",
+      "popupHtmlTemplate": "<img src=\"{{Image}}\" class=\"cdp-i cdp-i--c\" alt=\"{{Councilor}}\" style=\"margin-bottom: 1rem\"/>\n          <div class=\"ta-c m-v300\">\n            <div class=\"cdp-t t--sans t--upper m-t200\">{{Councilor}}</div>\n            <div class=\"cdp-st t--subinfo t--g300\">District {{DISTRICT}}</div>\n          </div>\n          <a href=\"{{Bio}}\" class=\"btn btn--b btn--100 btn--sm\">\n            Visit webpage<span class=\"a11y--h\"> of {{Councillor}}</span>\n          </a>",
       "data": {
         "type": "arcgis",
         "service": "https://services.arcgis.com/sFnw0xNflSi8J0uh/ArcGIS/rest/services/City_Council_Districts/FeatureServer",

--- a/web-components/html/snow-parking-modal.html
+++ b/web-components/html/snow-parking-modal.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html dir="ltr"
+  lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport"
+    content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
+  <title>Snow Emergency Parking</title>
+
+  <!--[if !IE]><!-->
+  <link rel="stylesheet"
+    type="text/css"
+    href="/css/public.css" />
+  <!--<![endif]-->
+  <!--[if lt IE 10]>
+    <link media="all" rel="stylesheet" href="/css/ie.css">
+  <![endif]-->
+
+</head>
+
+<body>
+  <div class="b b-c">
+    <div class="m-v300">
+      <a href="#map" class="btn">Open Map</a>
+      <cob-map id="map" modal>
+        <script type="application/json"
+          slot="config">
+          {
+            "version": "1.0",
+            "uid": "~ltT9D7MbvC7Wv0O6yYQr",
+            "dataSources": [
+              {
+                "uid": "lots",
+                 "icons": {
+                    "markerUrl": "https://patterns.boston.gov/images/global/icons/mapping/parking.svg",
+                    "cluster": false
+                },
+                "polygons": {
+                  "style": "default",
+                  "color": "#0C2639",
+                  "hoverColor": "#FB4D42"
+                },
+                "popupHtmlTemplate": "<div style=\"min-width: 280px\">\n        <h3 class=\"h3 m-v300\">{{Address}}</h4>\n        <div class=\"m-v300\">\n          <ul class=\"dl dl--sm\">\n            <li class=\"dl-i\"><span class=\"dl-t\">Name:</span> <span class=\"dl-d\">{{Name}}</span></li>\n            <li class=\"dl-i\"><span class=\"dl-t\">Fee:</span> <span class=\"dl-d\">{{Fee}}</span></li>\n          </ul>\n        </div>\n        {{#Comments}}<div class=\"t--subinfo m-v300\">{{.}}</div>{{/Comments}}\n        {{#Phone}}<div class=\"t--subinfo m-v300\">Call ahead to find out the number of spaces available: <a href=\"tel:{{.}}\">{{.}}</a></div>{{/Phone}}\n      </div>",
+                "data": {
+                  "type": "arcgis",
+                  "service": "https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/SnowParking/FeatureServer",
+                  "layer": 0
+                },
+                "legend": {
+                  "label": "Emergency Lots"
+                }
+              },
+              {
+                "uid": "streets",
+                "icons": null,
+                "polygons": {
+                  "style": "default",
+                  "color": "#FB4D42",
+                  "hoverColor": "#FB4D42"
+                },
+                "popupHtmlTemplate": "",
+                "data": {
+                  "type": "arcgis",
+                  "service": "https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/Ownership/FeatureServer",
+                  "layer": 0
+                },
+                "legend": {
+                  "label": "No Parking"
+                }
+              }
+            ],
+            "maps": [
+              {
+                "uid": "yBHcvxTmQyrK4WhLBxe16",
+                "title": "Snow Emergency Parking Restrictions",
+                "instructionsHtml": "<div class=\"t--info\"><div class=\"m-b200\">You can begin parking at participating lots and garages two hours before a declared snow emergency.</div><div>You must remove your vehicle within two hours of the City lifting the emergency ban.</div></div>",
+                "latitude": 42.32,
+                "longitude": -71.1284,
+                "zoom": 12,
+                "showZoomControl": true,
+                "showLegend": true,
+                "showUserLocation": false,
+                "addressSearch": {
+                  "title": "",
+                  "placeholder": "Search for your address…",
+                  "autoPopupDataSourceUid": null,
+                  "zoomToResult": true
+                }
+              }
+            ]
+          }    
+        </script>
+      </cob-viz>
+    </div>
+  </div>
+
+  <script src="/web-components/fleetcomponents.js"></script>
+</body>
+
+</html>

--- a/web-components/map/map.css
+++ b/web-components/map/map.css
@@ -87,21 +87,54 @@ cob-map .cob-map-modal-title {
   z-index: 501;
 }
 
-cob-map .cob-map-modal-title .sh {
+/* We have a wrapper we can put padding on without growing the bottom border */
+cob-map .cob-map-modal-header {
   flex-grow: 1;
+}
+
+cob-map .cob-map-modal-header .sh {
   padding-top: 0;
   padding-bottom: 0;
+  border-bottom-width: 0;
+
+  /* section header has to be flex at all breakpoints so that the toggle arrow
+  can be to the right of the title. */
+  display: flex;
+  align-items: center;
 }
 
 cob-map .cob-map-modal-title .sh-title {
   margin-bottom: 0;
+  flex-grow: 1;
+}
+
+cob-map .cob-map-controls-checkbox {
+  display: none;
+}
+
+cob-map .cob-map-controls-toggle {
+  flex-shrink: 0;
+  display: none;
+}
+
+cob-map .cob-map-controls-toggle svg {
+  display: block;
+  width: 20px;
+  height: 24px;
+  transform: rotate(-90deg);
+  transition: transform .25s;
+}
+
+cob-map .cob-map-controls-checkbox:checked~.cob-map-modal-contents .cob-map-controls-toggle svg {
+  transform: rotate(90deg);
 }
 
 cob-map .cob-map-modal-title .md-cb {
-  align-items: flex-start;
+  align-self: flex-start;
   border: none;
   z-index: 1000;
   position: relative;
+  flex-shrink: 0;
 }
 
 cob-map .cob-map-modal-contents .cob-map-leaflet-container {
@@ -115,16 +148,71 @@ cob-map .cob-map-modal-controls {
   align-items: center;
   position: relative;
   box-shadow: 0 -1px 2px 1px rgba(0, 0, 0, 0.1);
-  /* We want this to be high enough so that our box shadow goes over map tiles. */
+  /* We want this to be high enough so that our box shadow goes over map tiles,
+  but it has to be lower than the title so that it doesn't cover address suggestions.
+  */
   z-index: 500;
+}
+
+cob-map .cob-map-modal-legend {
+  display: flex;
+  align-items: center;
+  align-self: stretch;
+  flex-shrink: 0;
+  /* brings this to the right, regardless of the size of the content to the
+  left. */
+  margin-left: auto;
+  background: #f2f2f2;
+  /* Keeps the container (and its cells) centered if we grow. */
+  justify-content: center;
+}
+
+/* inner container is here so we can vertically center all of the legend icons,
+but have their tops all align. */
+cob-map .cob-map-modal-legend-cell-container {
+  display: flex;
+  align-items: flex-start;
+}
+
+cob-map .cob-map-modal-legend-cell {
+  padding: 1rem;
+  /* reliable way to get all child blocks horizontally centered */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+cob-map .cob-map-modal-legend-label {
+  margin-top: 0.5rem;
+  line-height: 1.2;
+  text-align: center;
+  font-family: 'Montserrat', Arial, sans-serif;
+  text-transform: uppercase;
+  color: #abaaab;
 }
 
 @media screen and (max-width: 479px) {
   cob-map .cob-map-modal-title {
     flex-direction: column;
     align-items: stretch;
-    padding: 0.5rem 0;
     box-shadow: 0 -1px 2px 1px rgba(0, 0, 0, 0.1);
+  }
+
+  /** Little hack to cover the bottom part of the box-shadow that's overlapping
+   * the controls element. We only do it when expanded, though, to prevent
+   * adding content offscreen. */
+  cob-map .cob-map-controls-checkbox:checked~.cob-map-modal-contents .cob-map-modal-title:after {
+    content: " ";
+    display: block;
+    position: absolute;
+    width: 100%;
+    height: 2px;
+    bottom: -2px;
+    background: white;
+  }
+
+  cob-map .cob-map-controls-toggle {
+    display: block;
   }
 
   cob-map .cob-map-modal-contents .md-cb {
@@ -137,14 +225,41 @@ cob-map .cob-map-modal-controls {
     order: -1;
   }
 
-  cob-map .cob-map-modal-controls {
-    box-shadow: none;
+  cob-map .cob-address-search-field-container {
+    /* The search field is in the title box, not the controls box, so it needs
+    its own hide/show when at mobile breakpoints. */
+    display: none;
+    margin-bottom: 1rem;
   }
 
-  /* When the address search is focused, we use margin to grow it big enough
-  that the results are available above the keyboard. */
-  cob-map .cob-address-search-field-container.focused {
-    margin-bottom: 40%;
+  cob-map .cob-map-controls-checkbox:checked~.cob-map-modal-contents .cob-address-search-field-container {
+    /* The address search box is small enough that it's ok that we don't animate
+    it the way we animate the bottom controls. */
+    display: block;
+  }
+
+  cob-map .cob-map-modal-controls {
+    box-shadow: none;
+    flex-direction: column;
+    align-items: stretch;
+    /* The old "we can't animate to an intristic height so let's cheat with
+    max-height" trick. */
+    max-height: 0;
+    transition: max-height 0.25s;
+    overflow-y: auto;
+  }
+
+  cob-map .cob-map-controls-checkbox:checked~.cob-map-modal-contents .cob-map-modal-controls {
+    max-height: 60vh;
+  }
+
+  cob-map .cob-map-modal-instructions {
+    padding-top: 0;
+  }
+
+  cob-map .cob-map-modal-legend {
+    /* we undo how this was pushed to the right on desktop. */
+    margin: 0;
   }
 }
 
@@ -223,7 +338,8 @@ cob-map .cob-legend-table-row {
   align-items: center;
 }
 
-cob-map .cob-legend-table-icon img {
+cob-map .cob-legend-table-icon img,
+cob-map .cob-map-modal-legend-icon img {
   display: block;
 }
 

--- a/web-components/map/map.tsx
+++ b/web-components/map/map.tsx
@@ -462,11 +462,15 @@ export class CobMap {
     }
   }
 
+  closeMobileOverlay() {
+    // If we're on mobile, the overlay was open to show the address search
+    // field. We close it to keep it from obscuring the results.
+    this.openOverlay = false;
+  }
+
   onAddressSearchResults(data) {
     if (data.results.length) {
-      // If we're on mobile, the overlay was open to show the address search
-      // field. We close it to keep it from obscuring the results.
-      this.openOverlay = false;
+      this.closeMobileOverlay();
     }
 
     if (!this.addressSearchResultsFeatures) {
@@ -522,6 +526,8 @@ export class CobMap {
       return null;
     }
 
+    this.closeMobileOverlay();
+
     return this.renderPopupContent(config, feature.properties || {});
   }
 
@@ -529,6 +535,8 @@ export class CobMap {
     layerConfig: LayerConfig,
     marker: LeafletMarker
   ) {
+    this.closeMobileOverlay();
+
     // When a marker is placed on the map we don't have any feature information
     // for it, so we need to query Esri for the properties we need to render the
     // popup.
@@ -712,11 +720,27 @@ export class CobMap {
     return (
       <div class="md md--fw">
         <div class="md-c">
+          <input
+            type="checkbox"
+            class="cob-map-controls-checkbox"
+            id={`cob-map-controls-checkbox-${this.idSuffix}`}
+            aria-hidden
+            checked={this.openOverlay}
+            onChange={ev =>
+              (this.openOverlay = (ev.target as HTMLInputElement).checked)
+            }
+          />
           <div class="cob-map-modal-contents">
             <div class="cob-map-modal-title">
-              <div class="sh sh--sm p-a300" style={{ borderBottom: 'none' }}>
-                <h2 class="sh-title">{this.heading}</h2>
-              </div>
+              <label
+                class="cob-map-modal-header p-a300"
+                htmlFor={`cob-map-controls-checkbox-${this.idSuffix}`}
+              >
+                <div class="sh sh--sm">
+                  <h2 class="sh-title">{this.heading}</h2>
+                  {this.renderControlsToggle()}
+                </div>
+              </label>
 
               {this.showAddressSearch && (
                 <div
@@ -740,7 +764,33 @@ export class CobMap {
             <div class="cob-map-leaflet-container" />
             <div class="cob-map-modal-controls">
               {this.instructionsHtml && (
-                <div class="p-a300" innerHTML={this.instructionsHtml} />
+                <div
+                  class="cob-map-modal-instructions p-a300"
+                  innerHTML={this.instructionsHtml}
+                />
+              )}
+
+              {this.showLegend && (
+                <div class="cob-map-modal-legend">
+                  <div class="cob-map-modal-legend-cell-container">
+                    {this.layerRecords
+                      .filter(
+                        ({ config }) =>
+                          config.legendSymbol && config.legendLabel
+                      )
+                      .map(({ config }) => (
+                        <div class="cob-map-modal-legend-cell">
+                          <div class="cob-map-modal-legend-icon">
+                            {this.renderLegendIcon(config)}
+                          </div>
+
+                          <div class="cob-map-modal-legend-label">
+                            {config.legendLabel}
+                          </div>
+                        </div>
+                      ))}
+                  </div>
+                </div>
               )}
             </div>
           </div>
@@ -808,6 +858,20 @@ export class CobMap {
             )}
           </div>
         </div>
+      </div>
+    );
+  }
+
+  renderControlsToggle() {
+    return (
+      <div class="cob-map-controls-toggle">
+        {/* Our standard blue disclosure arrow. */}
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="-2 8.5 18 25">
+          <path
+            fill="#288be4"
+            d="M16 21L.5 33.2c-.6.5-1.5.4-2.2-.2-.5-.6-.4-1.6.2-2l12.6-10-12.6-10c-.6-.5-.7-1.5-.2-2s1.5-.7 2.2-.2L16 21z"
+          />
+        </svg>
       </div>
     );
   }


### PR DESCRIPTION
Updates the modal UI to have a togglable footer element now that there's
more content to go in there.

Fixes #332

Also:
 - Adds cdp-i--c to keep the city councilor heads from left-aligning on
   mobile breakpoints in our popups.