### PR TITLE
Maps punchlist

### DIFF
--- a/web-components/html/city-council-modal.html
+++ b/web-components/html/city-council-modal.html
@@ -36,6 +36,7 @@
       "polygons": {
         "style": "default",
         "color": "#0C2639",
+        "fill": true,
         "hoverColor": "#FB4D42"
       },
       "popupHtmlTemplate": "<img src=\"{{Image}}\" class=\"cdp-i cdp-i--c\" alt=\"{{Councilor}}\" style=\"margin-bottom: 1rem\"/>\n          <div class=\"ta-c m-v300\">\n            <div class=\"cdp-t t--sans t--upper m-t200\">{{Councilor}}</div>\n            <div class=\"cdp-st t--subinfo t--g300\">District {{DISTRICT}}</div>\n          </div>\n          <a href=\"{{Bio}}\" class=\"btn btn--b btn--100 btn--sm\">\n            Visit webpage<span class=\"a11y--h\"> of {{Councillor}}</span>\n          </a>",
@@ -60,12 +61,12 @@
       "zoom": 12,
       "showZoomControl": true,
       "showLegend": true,
-      "showUserLocation": false,
+      "showUserLocation": true,
       "addressSearch": {
         "title": "",
         "placeholder": "Search for your address…",
         "autoPopupDataSourceUid": "0QYJNIqaMzWBtanIvWles",
-        "zoomToResult": false
+        "zoomToResult": true
       }
     }
   ]

--- a/web-components/html/city-council.html
+++ b/web-components/html/city-council.html
@@ -42,6 +42,7 @@
       "polygons": {
         "style": "default",
         "color": "#0C2639",
+        "fill": true,
         "hoverColor": "#FB4D42"
       },
       "popupHtmlTemplate": "<img src=\"{{Image}}\" class=\"cdp-i cdp-i--c\" alt=\"{{Councilor}}\" style=\"margin-bottom: 1rem\"/>\n          <div class=\"ta-c m-v300\">\n            <div class=\"cdp-t t--sans t--upper m-t200\">{{Councilor}}</div>\n            <div class=\"cdp-st t--subinfo t--g300\">District {{DISTRICT}}</div>\n          </div>\n          <a href=\"{{Bio}}\" class=\"btn btn--b btn--100 btn--sm\">\n            Visit webpage<span class=\"a11y--h\"> of {{Councillor}}</span>\n          </a>",

--- a/web-components/map/map.css
+++ b/web-components/map/map.css
@@ -90,6 +90,8 @@ cob-map .cob-map-modal-title {
 /* We have a wrapper we can put padding on without growing the bottom border */
 cob-map .cob-map-modal-header {
   flex-grow: 1;
+  /* overwrites boston.gov style */
+  margin: 0;
 }
 
 cob-map .cob-map-modal-header .sh {
@@ -133,12 +135,27 @@ cob-map
   transform: rotate(90deg);
 }
 
+/* When these are used in popups we want to tweak them to keep the titles from
+overlapping the content. */
+cob-map .leaflet-popup .dl-t {
+  width: auto;
+  min-width: 20%;
+  padding-right: 0.5em;
+}
+
+cob-map .leaflet-popup .dl-d {
+  width: auto;
+  max-width: 80%;
+}
+
 cob-map .cob-map-modal-title .md-cb {
   align-self: flex-start;
   border: none;
   z-index: 1000;
   position: relative;
   flex-shrink: 0;
+  /* Overwrites a Boston.gov style */
+  margin-top: 0;
 }
 
 cob-map .cob-map-modal-contents .cob-map-leaflet-container {
@@ -291,11 +308,6 @@ cob-map .cob-map-modal-legend-label {
     /* we undo how this was pushed to the right on desktop. */
     margin: 0;
   }
-}
-
-cob-map svg {
-  width: initial;
-  height: initial;
 }
 
 cob-map .geocoder-control-suggestions {


### PR DESCRIPTION
 - Makes map lines semi-transparent at closer zoom levels
 - Changes dls in popups to be flexible with label width so that they
   don't overlap the content
 - Adds searching for user location
 - Makes address search not zoom in as far

Fixes #220, #345, #343, #342
