### PR TITLE
Adds height/width to img in grid of cards

### DIFF
--- a/legacy/hub.styl
+++ b/legacy/hub.styl
@@ -6418,6 +6418,8 @@ section.contact-departments,
 }
 .grid-card__image>img {
     display: block
+    width: 100%
+    height: 100%
 }
 .grid-card {
     background-color: #fff

--- a/legacy/public.styl
+++ b/legacy/public.styl
@@ -5590,6 +5590,8 @@ section.contact-departments,
 }
 .grid-card__image>img {
     display: block
+    width: 100%
+    height: 100%
 }
 .grid-card {
     background-color: $white


### PR DESCRIPTION
This HTML is used on the Budget site, and was broken by the recent
removal of the global width/height CSS style.