### PR TITLE
Final fix smaller screen issues.  Force word breaks in table column.

### DIFF
--- a/stylesheets/components/drawers/_drawer.styl
+++ b/stylesheets/components/drawers/_drawer.styl
@@ -101,7 +101,8 @@
         .responsive-table
           font-size: 4.5vw
           border: 1px solid black
-
+          word-wrap: break-word;
+          word-break: break-word;
   &-ic
     height: 20px
     width: 26px


### PR DESCRIPTION
Adds css to ensure columns do not extend wider than page boundary as page width shrinks.
Issue #302 (Drupal 7 backlog)
@finneganh 