### PR TITLE
Makes map popup corners square

### DIFF
--- a/web-components/map/map.css
+++ b/web-components/map/map.css
@@ -7,7 +7,11 @@ cob-map h3 {
   font-style: inherit;
 }
 
-cob-map.leaflet-container a.leaflet-popup-close-button {
+cob-map .leaflet-container .leaflet-popup-content-wrapper {
+  border-radius: 0;
+}
+
+cob-map .leaflet-container a.leaflet-popup-close-button {
   /* By default this is too tight in the corner */
   top: 6px;
   right: 6px;


### PR DESCRIPTION
Fixes #254

Also fixes CSS to position the popup close box. Old version was for
inline display, rather than the modal display.