### PR TITLE
Radio label fix

### DIFF
--- a/stylesheets/components/form/_radio.styl
+++ b/stylesheets/components/form/_radio.styl
@@ -71,6 +71,7 @@
       -moz-appearance: none
 
   &-l
+    color: $charles-blue
     font-family: $serif
     font-size: responsive 16px 20px
     font-range: 480px 1440px

--- a/stylesheets/components/form/_radio.styl
+++ b/stylesheets/components/form/_radio.styl
@@ -18,6 +18,11 @@
   display: flex
   align-items: center
 
+  label&
+    // needed to override legacy styles in production
+    letter-spacing: normal
+    text-transform: none
+
   &:not(:last-child)
     margin-bottom: $sizing-200
 
@@ -66,7 +71,6 @@
       -moz-appearance: none
 
   &-l
-    color: $charles-blue
     font-family: $serif
     font-size: responsive 16px 20px
     font-range: 480px 1440px


### PR DESCRIPTION
`legacy.css` applies styling that affects radio button label text; we want to override this styling.