### PR TITLE
Adding charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 /assets
 /public
 deploy_key
+.vscode/

--- a/package-lock.json
+++ b/package-lock.json
@@ -729,6 +729,19 @@
       "integrity": "sha1-yDpx/gLIx+HM7ASN1qJFjR9sluo=",
       "dev": true
     },
+    "@types/d3-dsv": {
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.0.33.tgz",
+      "integrity": "sha512-jx5YvaVC3Wfh6LobaiWTeU1NkvL2wPmmpmajk618bD+xVz98yNWzmZMvmlPHGK0HXbMeHmW/6oVX48V9AH1bRQ=="
+    },
+    "@types/d3-fetch": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-1.1.2.tgz",
+      "integrity": "sha512-w6ANZv/mUh+6IV3drT22zgPWMRobzuGXhzOZC8JPD+ygce0/Vx6vTci3m3dizkocnQQCOwNbrWWWPYqpWiKzRQ==",
+      "requires": {
+        "@types/d3-dsv": "1.0.33"
+      }
+    },
     "@types/error-stack-parser": {
       "version": "1.3.18",
       "resolved": "https://registry.npmjs.org/@types/error-stack-parser/-/error-stack-parser-1.3.18.tgz",
@@ -1048,10 +1061,26 @@
         "default-require-extensions": "1.0.0"
       }
     },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "optional": true
+    },
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "optional": true,
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.3"
+      }
     },
     "argparse": {
       "version": "1.0.9",
@@ -2276,6 +2305,14 @@
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
     },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
@@ -2834,6 +2871,34 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000856.tgz",
       "integrity": "sha512-x3mYcApHMQemyaHuH/RyqtKCGIYTgEA63fdi+VBvDz8xUSmRiVWTLeyKcoGQCGG6UPR9/+4qG4OKrTa6aSQRKg==",
       "dev": true
+    },
+    "canvas": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-1.6.11.tgz",
+      "integrity": "sha512-ElVw5Uk8PReGpzXfDg6PDa+wntnZLGWWfdSHI0Pc8GyXiFbW13drSTzWU6C4E5QylHe+FnLqI7ngMRlp3eGZIQ==",
+      "optional": true,
+      "requires": {
+        "nan": "2.11.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
+          "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+          "optional": true
+        }
+      }
+    },
+    "canvas-prebuilt": {
+      "version": "1.6.5-prerelease.1",
+      "resolved": "https://registry.npmjs.org/canvas-prebuilt/-/canvas-prebuilt-1.6.5-prerelease.1.tgz",
+      "integrity": "sha1-aBSyC5yAg13MJL/WGZFHKIYwUhw=",
+      "optional": true,
+      "requires": {
+        "node-pre-gyp": "0.6.39",
+        "parse-css-font": "2.0.2",
+        "units-css": "0.4.0"
+      }
     },
     "capture-stack-trace": {
       "version": "1.0.0",
@@ -3455,6 +3520,11 @@
       "integrity": "sha1-v+dyOMdL5FOnnwy2BY3utPI1jpM=",
       "dev": true
     },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -3672,6 +3742,45 @@
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
     },
+    "css-font-size-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
+      "integrity": "sha1-hUh1rOmspqjS7g00WkSq6btttss=",
+      "optional": true
+    },
+    "css-font-stretch-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
+      "integrity": "sha1-UM7puboDH7XJUtRyMTnx4Qe1SxA=",
+      "optional": true
+    },
+    "css-font-style-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
+      "integrity": "sha1-XDUygT9jtKHelU0TzqhqtDM0CeQ=",
+      "optional": true
+    },
+    "css-font-weight-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
+      "integrity": "sha1-m8BGcayFvHJLV07106yWsNYE/Zc=",
+      "optional": true
+    },
+    "css-global-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
+      "integrity": "sha1-cqmupyeW0Bmx0qMlLeTlqqN+Smk=",
+      "optional": true
+    },
+    "css-list-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-list-helpers/-/css-list-helpers-1.0.1.tgz",
+      "integrity": "sha1-//VxkiAtuDJAxBaG+RnkSacCT30=",
+      "optional": true,
+      "requires": {
+        "tcomb": "2.7.0"
+      }
+    },
     "css-parse": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz",
@@ -3694,6 +3803,12 @@
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.0.tgz",
       "integrity": "sha1-AQKz0UYw34bD65+p9UVicBBs+ZA=",
       "dev": true
+    },
+    "css-system-font-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
+      "integrity": "sha1-hcbwhquk6zLFcaMIav/ENLhII+0=",
+      "optional": true
     },
     "css-tree": {
       "version": "1.0.0-alpha25",
@@ -3839,6 +3954,152 @@
       "requires": {
         "es5-ext": "0.10.42"
       }
+    },
+    "d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+    },
+    "d3-color": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.2.3.tgz",
+      "integrity": "sha512-x37qq3ChOTLd26hnps36lexMRhNXEtVxZ4B25rL0DVdDsGQIJGB18S7y9XDwlDD6MD/ZBzITCf4JjGMM10TZkw=="
+    },
+    "d3-contour": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-1.3.2.tgz",
+      "integrity": "sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==",
+      "requires": {
+        "d3-array": "1.2.4"
+      }
+    },
+    "d3-dispatch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.5.tgz",
+      "integrity": "sha512-vwKx+lAqB1UuCeklr6Jh1bvC4SZgbSqbkGBLClItFBIYH4vqDJCA7qfoy14lXmJdnBOdxndAMxjCbImJYW7e6g=="
+    },
+    "d3-dsv": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.10.tgz",
+      "integrity": "sha512-vqklfpxmtO2ZER3fq/B33R/BIz3A1PV0FaZRuFM8w6jLo7sUX1BZDh73fPlr0s327rzq4H6EN1q9U+eCBCSN8g==",
+      "requires": {
+        "commander": "2.13.0",
+        "iconv-lite": "0.4.19",
+        "rw": "1.3.3"
+      }
+    },
+    "d3-fetch": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-1.1.2.tgz",
+      "integrity": "sha512-S2loaQCV/ZeyTyIF2oP8D1K9Z4QizUzW7cWeAOAS4U88qOt3Ucf6GsmgthuYSdyB2HyEm4CeGvkQxWsmInsIVA==",
+      "requires": {
+        "d3-dsv": "1.0.10"
+      }
+    },
+    "d3-force": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.2.tgz",
+      "integrity": "sha512-p1vcHAUF1qH7yR+e8ip7Bs61AHjLeKkIn8Z2gzwU2lwEf2wkSpWdjXG0axudTHsVFnYGlMkFaEsVy2l8tAg1Gw==",
+      "requires": {
+        "d3-collection": "1.0.7",
+        "d3-dispatch": "1.0.5",
+        "d3-quadtree": "1.0.5",
+        "d3-timer": "1.0.9"
+      }
+    },
+    "d3-format": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.3.2.tgz",
+      "integrity": "sha512-Z18Dprj96ExragQ0DeGi+SYPQ7pPfRMtUXtsg/ChVIKNBCzjO8XYJvRTC1usblx52lqge56V5ect+frYTQc8WQ=="
+    },
+    "d3-geo": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.11.1.tgz",
+      "integrity": "sha512-GsG7x9G9sykseLviOVSJ3h5yjw0ItLopOtuDQKUt1TRklEegCw5WAmnIpYYiCkSH/QgUMleAeE2xZK38Qb+1+Q==",
+      "requires": {
+        "d3-array": "1.2.4"
+      }
+    },
+    "d3-hierarchy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz",
+      "integrity": "sha512-L+GHMSZNwTpiq4rt9GEsNcpLa4M96lXMR8M/nMG9p5hBE0jy6C+3hWtyZMenPQdwla249iJy7Nx0uKt3n+u9+w=="
+    },
+    "d3-interpolate": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.3.2.tgz",
+      "integrity": "sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==",
+      "requires": {
+        "d3-color": "1.2.3"
+      }
+    },
+    "d3-path": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.7.tgz",
+      "integrity": "sha512-q0cW1RpvA5c5ma2rch62mX8AYaiLX0+bdaSM2wxSU9tXjU4DNvkx9qiUvjkuWCj3p22UO/hlPivujqMiR9PDzA=="
+    },
+    "d3-quadtree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.5.tgz",
+      "integrity": "sha512-U2tjwDFbZ75JRAg8A+cqMvqPg1G3BE7UTJn3h8DHjY/pnsAfWdbJKgyfcy7zKjqGtLAmI0q8aDSeG1TVIKRaHQ=="
+    },
+    "d3-scale": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.1.2.tgz",
+      "integrity": "sha512-bESpd64ylaKzCDzvULcmHKZTlzA/6DGSVwx7QSDj/EnX9cpSevsdiwdHFYI9ouo9tNBbV3v5xztHS2uFeOzh8Q==",
+      "requires": {
+        "d3-array": "1.2.4",
+        "d3-collection": "1.0.7",
+        "d3-format": "1.3.2",
+        "d3-interpolate": "1.3.2",
+        "d3-time": "1.0.10",
+        "d3-time-format": "2.1.3"
+      }
+    },
+    "d3-scale-chromatic": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.3.3.tgz",
+      "integrity": "sha512-BWTipif1CimXcYfT02LKjAyItX5gKiwxuPRgr4xM58JwlLocWbjPLI7aMEjkcoOQXMkYsmNsvv3d2yl/OKuHHw==",
+      "requires": {
+        "d3-color": "1.2.3",
+        "d3-interpolate": "1.3.2"
+      }
+    },
+    "d3-shape": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.2.2.tgz",
+      "integrity": "sha512-hUGEozlKecFZ2bOSNt7ENex+4Tk9uc/m0TtTEHBvitCBxUNjhzm5hS2GrrVRD/ae4IylSmxGeqX5tWC2rASMlQ==",
+      "requires": {
+        "d3-path": "1.0.7"
+      }
+    },
+    "d3-time": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.10.tgz",
+      "integrity": "sha512-hF+NTLCaJHF/JqHN5hE8HVGAXPStEq6/omumPE/SxyHVrR7/qQxusFDo0t0c/44+sCGHthC7yNGFZIEgju0P8g=="
+    },
+    "d3-time-format": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.3.tgz",
+      "integrity": "sha512-6k0a2rZryzGm5Ihx+aFMuO1GgelgIz+7HhB4PH4OEndD5q2zGn1mDfRdNrulspOfR6JXkb2sThhDK41CSK85QA==",
+      "requires": {
+        "d3-time": "1.0.10"
+      }
+    },
+    "d3-timer": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.9.tgz",
+      "integrity": "sha512-rT34J5HnQUHhcLvhSB9GjCkN0Ddd5Y8nCwDBG2u6wQEeYxT/Lf51fTFFkldeib/sE/J0clIe0pnCfs6g/lRbyg=="
+    },
+    "d3-voronoi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
+      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -4041,6 +4302,12 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "optional": true
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -4087,6 +4354,12 @@
       "requires": {
         "repeating": "2.0.1"
       }
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "optional": true
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -5086,7 +5359,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "dev": true,
       "requires": {
         "cross-spawn": "5.1.0",
         "get-stream": "3.0.0",
@@ -5101,7 +5373,6 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
           "requires": {
             "lru-cache": "4.1.1",
             "shebang-command": "1.2.0",
@@ -5112,7 +5383,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
           "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-          "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
             "yallist": "2.1.2"
@@ -6627,6 +6897,28 @@
         }
       }
     },
+    "fstream": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "fstream-ignore": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+      "optional": true,
+      "requires": {
+        "fstream": "1.0.11",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4"
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -6674,6 +6966,22 @@
       "resolved": "https://registry.npmjs.org/gather-stream/-/gather-stream-1.0.0.tgz",
       "integrity": "sha1-szmUr0V6gRVwDUEPMXczy+egkEs="
     },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "optional": true,
+      "requires": {
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.3"
+      }
+    },
     "gaze": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
@@ -6708,8 +7016,7 @@
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
       "version": "2.0.6",
@@ -7444,6 +7751,12 @@
       "requires": {
         "sparkles": "1.0.0"
       }
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "optional": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -8290,6 +8603,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isnumeric": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/isnumeric/-/isnumeric-0.2.0.tgz",
+      "integrity": "sha1-ojR7o2DeGeM9D/1ZD933dVy/LmQ=",
+      "optional": true
     },
     "isobject": {
       "version": "2.1.0",
@@ -9808,6 +10127,11 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-stringify-pretty-compact": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-1.2.0.tgz",
+      "integrity": "sha512-/11Pj1OyX814QMKO7K8l85SHPTr/KsFxHp8GE2zVa0BtJgGimDjXHfM3FhC7keQdWDea7+nXf+f1de7ATZcZkQ=="
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -11010,7 +11334,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true,
       "requires": {
         "mimic-fn": "1.1.0"
       }
@@ -11106,8 +11429,7 @@
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-      "dev": true
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
     },
     "min-document": {
       "version": "2.19.0",
@@ -11420,6 +11742,11 @@
         }
       }
     },
+    "node-fetch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
+      "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -11441,6 +11768,37 @@
         "semver": "5.5.0",
         "shellwords": "0.1.1",
         "which": "1.3.0"
+      }
+    },
+    "node-pre-gyp": {
+      "version": "0.6.39",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+      "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
+      "optional": true,
+      "requires": {
+        "detect-libc": "1.0.3",
+        "hawk": "3.1.3",
+        "mkdirp": "0.5.1",
+        "nopt": "4.0.1",
+        "npmlog": "4.1.2",
+        "rc": "1.2.5",
+        "request": "2.81.0",
+        "rimraf": "2.6.2",
+        "semver": "5.5.0",
+        "tar": "2.2.1",
+        "tar-pack": "3.4.1"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.4"
+          }
+        }
       }
     },
     "node-status-codes": {
@@ -11510,7 +11868,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
       "requires": {
         "path-key": "2.0.1"
       }
@@ -11524,6 +11881,18 @@
         "commander": "2.13.0",
         "npm-path": "2.0.4",
         "which": "1.3.0"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "optional": true,
+      "requires": {
+        "are-we-there-yet": "1.1.5",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
       }
     },
     "nth-check": {
@@ -11946,8 +12315,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "1.2.0",
@@ -12022,6 +12390,23 @@
       "requires": {
         "xml-parse-from-string": "1.0.1",
         "xml2js": "0.4.19"
+      }
+    },
+    "parse-css-font": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/parse-css-font/-/parse-css-font-2.0.2.tgz",
+      "integrity": "sha1-e2CwYHBaJam5C38O1JPlgjJIplI=",
+      "optional": true,
+      "requires": {
+        "css-font-size-keywords": "1.0.0",
+        "css-font-stretch-keywords": "1.0.1",
+        "css-font-style-keywords": "1.0.1",
+        "css-font-weight-keywords": "1.0.0",
+        "css-global-keywords": "1.0.1",
+        "css-list-helpers": "1.0.1",
+        "css-system-font-keywords": "1.0.0",
+        "tcomb": "2.7.0",
+        "unquote": "1.1.1"
       }
     },
     "parse-filepath": {
@@ -12139,8 +12524,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.5",
@@ -14900,6 +15284,11 @@
         "gulp-util": "3.0.8"
       }
     },
+    "rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+    },
     "rx": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
@@ -15220,7 +15609,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "1.0.0"
       }
@@ -15228,8 +15616,7 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shelljs": {
       "version": "0.7.8",
@@ -15255,8 +15642,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
       "version": "1.17.7",
@@ -15846,8 +16232,7 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -16035,6 +16420,37 @@
       "requires": {
         "connected-domain": "1.0.0"
       }
+    },
+    "tar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "requires": {
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
+      }
+    },
+    "tar-pack": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
+      "integrity": "sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==",
+      "optional": true,
+      "requires": {
+        "debug": "2.6.9",
+        "fstream": "1.0.11",
+        "fstream-ignore": "1.0.5",
+        "once": "1.4.0",
+        "readable-stream": "2.3.3",
+        "rimraf": "2.6.2",
+        "tar": "2.2.1",
+        "uid-number": "0.0.6"
+      }
+    },
+    "tcomb": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tcomb/-/tcomb-2.7.0.tgz",
+      "integrity": "sha1-ENYpWAQWaaXVNWe5pO6M3iKxwrA="
     },
     "temp-fs": {
       "version": "0.9.9",
@@ -16829,6 +17245,14 @@
         }
       }
     },
+    "topojson-client": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.0.0.tgz",
+      "integrity": "sha1-H5kpOnfvQqRI0DKoGqmCtz82DS8=",
+      "requires": {
+        "commander": "2.13.0"
+      }
+    },
     "tough-cookie": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
@@ -16877,6 +17301,11 @@
       "requires": {
         "utf8-byte-length": "1.0.4"
       }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -16977,6 +17406,12 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "optional": true
     },
+    "uid-number": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+      "optional": true
+    },
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
@@ -17051,6 +17486,16 @@
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
       "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs="
     },
+    "units-css": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/units-css/-/units-css-0.4.0.tgz",
+      "integrity": "sha1-1iKGU6UZg9fBb/KPi53Dsf/tOgc=",
+      "optional": true,
+      "requires": {
+        "isnumeric": "0.2.0",
+        "viewport-dimensions": "0.2.0"
+      }
+    },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
@@ -17064,8 +17509,7 @@
     "unquote": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
-      "dev": true
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
     },
     "unset-value": {
       "version": "1.0.0",
@@ -17346,6 +17790,579 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
+    "vega": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-4.2.0.tgz",
+      "integrity": "sha1-KBhWWkH5kJ8EJ26dV4bBq1XyrrM=",
+      "requires": {
+        "canvas": "1.6.11",
+        "canvas-prebuilt": "1.6.5-prerelease.1",
+        "vega-lib": "4.2.0",
+        "vega-parser": "3.7.2",
+        "vega-typings": "0.3.40",
+        "yargs": "12.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "decamelize": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+          "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+          "requires": {
+            "xregexp": "4.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "requires": {
+            "p-try": "2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+        },
+        "yargs": {
+          "version": "12.0.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
+          "integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
+          "requires": {
+            "cliui": "4.1.0",
+            "decamelize": "2.0.0",
+            "find-up": "3.0.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "10.1.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "requires": {
+            "camelcase": "4.1.0"
+          }
+        }
+      }
+    },
+    "vega-canvas": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.1.0.tgz",
+      "integrity": "sha512-0RBwjnrFf4VRhNm5ICY+o1/q6mynli+VheOXKGML9mElRsplZgzd/pv9NnNRNigU+M66Kr7zUpskoakh8EhW9Q=="
+    },
+    "vega-crossfilter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-3.0.0.tgz",
+      "integrity": "sha512-h8HLc0YGaCFx3XTJYe2ixDQKHErvAFmFCE5EzLf7qmoWKtfXvXqB0+YcV/h5XC6VmLdUwFzMah+deDjIwncq7g==",
+      "requires": {
+        "d3-array": "1.2.4",
+        "vega-dataflow": "4.0.4",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-dataflow": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-4.0.4.tgz",
+      "integrity": "sha1-4vS0gFYY0BwLgzqTSE08JEZ1+6M=",
+      "requires": {
+        "vega-loader": "3.0.1",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-encode": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-3.1.4.tgz",
+      "integrity": "sha1-7PG963oBvAfthvsL+2rjLTT2J5s=",
+      "requires": {
+        "d3-array": "1.2.4",
+        "d3-format": "1.3.2",
+        "d3-interpolate": "1.3.2",
+        "vega-dataflow": "4.0.4",
+        "vega-scale": "2.4.0",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-event-selector": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-2.0.0.tgz",
+      "integrity": "sha512-EZeStM/7LNfJiRuop0lvhOR52Q1l9i/EIYUnm/XddhjR+UqhPkeCmZcffMTr41z3aGm/zciVLlKanUWNT+jQ1A=="
+    },
+    "vega-expression": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-2.3.1.tgz",
+      "integrity": "sha512-BOf+7XuzsubcbiLJkgyvnywse1+NY72HhzFPQqwUIfloaH9U6m2sNfMhc353ODWF9UFpKXSQ9r4tWohTj64kNQ==",
+      "requires": {
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-3.0.0.tgz",
+      "integrity": "sha512-Uar26RDxDQEpIdWBIFKnOr6/B30RU8/2qBtoiux1C3goZIWBRkXNlCR5kMDkll8Mg60deD6ynflsXXNwyGS69w==",
+      "requires": {
+        "d3-force": "1.1.2",
+        "vega-dataflow": "4.0.4",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-3.1.0.tgz",
+      "integrity": "sha1-ICLw3GEhmVhbENInSWf+6U11BbQ=",
+      "requires": {
+        "d3-array": "1.2.4",
+        "d3-contour": "1.3.2",
+        "d3-geo": "1.11.1",
+        "vega-dataflow": "4.0.4",
+        "vega-projection": "1.2.0",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-hierarchy": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-3.0.3.tgz",
+      "integrity": "sha1-AAPtWerNunAlagDJw54WQ0JGYuw=",
+      "requires": {
+        "d3-collection": "1.0.7",
+        "d3-hierarchy": "1.1.8",
+        "vega-dataflow": "4.0.4",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-lib": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vega-lib/-/vega-lib-4.2.0.tgz",
+      "integrity": "sha1-eK3AhsewIw2ltBw/38AgK0jiKPo=",
+      "requires": {
+        "vega-crossfilter": "3.0.0",
+        "vega-dataflow": "4.0.4",
+        "vega-encode": "3.1.4",
+        "vega-event-selector": "2.0.0",
+        "vega-expression": "2.3.1",
+        "vega-force": "3.0.0",
+        "vega-geo": "3.1.0",
+        "vega-hierarchy": "3.0.3",
+        "vega-loader": "3.0.1",
+        "vega-parser": "3.7.2",
+        "vega-projection": "1.2.0",
+        "vega-runtime": "3.1.0",
+        "vega-scale": "2.4.0",
+        "vega-scenegraph": "3.2.2",
+        "vega-statistics": "1.2.1",
+        "vega-transforms": "2.2.0",
+        "vega-typings": "0.3.40",
+        "vega-util": "1.7.0",
+        "vega-view": "3.3.3",
+        "vega-view-transforms": "2.0.2",
+        "vega-voronoi": "3.0.0",
+        "vega-wordcloud": "3.0.0"
+      }
+    },
+    "vega-lite": {
+      "version": "3.0.0-rc5",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-3.0.0-rc5.tgz",
+      "integrity": "sha512-7u4LUYdYblVCmPvh4CBDrylT1s5zbEfIYzpTTzS1tsx2e0Wenu06BwHKJsT9mUBM+RNhymVfUoR5O/l6+e/qBg==",
+      "requires": {
+        "json-stable-stringify": "1.0.1",
+        "json-stringify-pretty-compact": "1.2.0",
+        "tslib": "1.9.3",
+        "vega-event-selector": "2.0.0",
+        "vega-typings": "0.3.40",
+        "vega-util": "1.7.0",
+        "yargs": "12.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "decamelize": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+          "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+          "requires": {
+            "xregexp": "4.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "requires": {
+            "p-try": "2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+        },
+        "yargs": {
+          "version": "12.0.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
+          "integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
+          "requires": {
+            "cliui": "4.1.0",
+            "decamelize": "2.0.0",
+            "find-up": "3.0.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "10.1.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "requires": {
+            "camelcase": "4.1.0"
+          }
+        }
+      }
+    },
+    "vega-loader": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-3.0.1.tgz",
+      "integrity": "sha1-coQmtU503n28kdQY4FIwvH7iOog=",
+      "requires": {
+        "d3-dsv": "1.0.10",
+        "d3-time-format": "2.1.3",
+        "node-fetch": "2.2.0",
+        "topojson-client": "3.0.0",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-parser": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-3.7.2.tgz",
+      "integrity": "sha1-A7fOG89Ms+3S+BV2k3Ajov+sFn0=",
+      "requires": {
+        "d3-array": "1.2.4",
+        "d3-color": "1.2.3",
+        "d3-format": "1.3.2",
+        "d3-geo": "1.11.1",
+        "d3-time-format": "2.1.3",
+        "vega-dataflow": "4.0.4",
+        "vega-event-selector": "2.0.0",
+        "vega-expression": "2.3.1",
+        "vega-scale": "2.4.0",
+        "vega-scenegraph": "3.2.2",
+        "vega-statistics": "1.2.1",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-projection": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.2.0.tgz",
+      "integrity": "sha1-gSyVUlHatJX9qD2UBrpy2YM6IBQ=",
+      "requires": {
+        "d3-geo": "1.11.1"
+      }
+    },
+    "vega-runtime": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-3.1.0.tgz",
+      "integrity": "sha1-yL09Zb7yjK4LG7yN37zWt25eYBM=",
+      "requires": {
+        "vega-dataflow": "4.0.4",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-scale": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-2.4.0.tgz",
+      "integrity": "sha1-GEsRl55kNGPtRd+ukULkK1o17sw=",
+      "requires": {
+        "d3-array": "1.2.4",
+        "d3-interpolate": "1.3.2",
+        "d3-scale": "2.1.2",
+        "d3-scale-chromatic": "1.3.3",
+        "d3-time": "1.0.10",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-scenegraph": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-3.2.2.tgz",
+      "integrity": "sha1-btXzf2N8fl7tcCYh6sxoscbtTNs=",
+      "requires": {
+        "d3-path": "1.0.7",
+        "d3-shape": "1.2.2",
+        "vega-canvas": "1.1.0",
+        "vega-loader": "3.0.1",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-statistics": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.2.1.tgz",
+      "integrity": "sha512-70CC6rbS1RFVEpKT/qOGHhHATeh92cB2gXnjg+zErrY8255cBlOW8X0s4iZBsoa4vibGXb42imyM+rxAwL1VPA==",
+      "requires": {
+        "d3-array": "1.2.4"
+      }
+    },
+    "vega-tooltip": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-0.13.0.tgz",
+      "integrity": "sha512-NbeHzpxwKZ+yk+CION3wRH66rx9XGx5v6M82LT6qSIAnUrH8eh+sFtjK6pO7ErXGF5AieAhg8Hfb/NvC8uNMuA==",
+      "requires": {
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-transforms": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-2.2.0.tgz",
+      "integrity": "sha1-X0J2Mqv21CJiSUNfrfC419dOebw=",
+      "requires": {
+        "d3-array": "1.2.4",
+        "vega-dataflow": "4.0.4",
+        "vega-statistics": "1.2.1",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-typings": {
+      "version": "0.3.40",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.3.40.tgz",
+      "integrity": "sha512-0MPIrRGCsNm3pBcdIJzOlATO1eu45sg7GLml6nd39TDGX7xuPdDoyWFKaMDTZ3wmFHHCF0ykqO0KI8w3T2YOCw==",
+      "requires": {
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-util": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.7.0.tgz",
+      "integrity": "sha512-IlmYqW0t3UP8AJX4QuOOm5cMPKPOUa8fSTcCvNkfVOR5zvMNFKCVhoZmJSXgcbEhkfboB+ysI2aaWOeW2kKBog=="
+    },
+    "vega-view": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-3.3.3.tgz",
+      "integrity": "sha1-qoEXdf5fFxYgvC9TV9PeFYXkzhI=",
+      "requires": {
+        "d3-array": "1.2.4",
+        "d3-timer": "1.0.9",
+        "vega-dataflow": "4.0.4",
+        "vega-parser": "3.7.2",
+        "vega-runtime": "3.1.0",
+        "vega-scenegraph": "3.2.2",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-view-transforms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-2.0.2.tgz",
+      "integrity": "sha1-XCh3u55+vvKW90C2DF4WEtJmbc0=",
+      "requires": {
+        "vega-dataflow": "4.0.4",
+        "vega-scenegraph": "3.2.2",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-voronoi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-3.0.0.tgz",
+      "integrity": "sha512-ZkQw4UprxqiS3IjrdLOoQq1oEeH0REqWonf7Wz5zt2pKDHyMPlFX89EueoDYOKnfQjk9/7IiptBDK1ruAbDNiQ==",
+      "requires": {
+        "d3-voronoi": "1.1.4",
+        "vega-dataflow": "4.0.4",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-wordcloud": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-3.0.0.tgz",
+      "integrity": "sha512-/2F09L2tNTQ8aqK/ZLjd7m+fYwJR8/waE8YWuexLZob4+4BEByzqFfRMATE39ZpdTHOreCEQ5uUKyvv0qA6O0A==",
+      "requires": {
+        "vega-canvas": "1.1.0",
+        "vega-dataflow": "4.0.4",
+        "vega-scale": "2.4.0",
+        "vega-statistics": "1.2.1",
+        "vega-util": "1.7.0"
+      }
+    },
     "vendors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
@@ -17367,6 +18384,12 @@
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
+    },
+    "viewport-dimensions": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/viewport-dimensions/-/viewport-dimensions-0.2.0.tgz",
+      "integrity": "sha1-3nQHR9tTh/0XJfUXXpG6x2r982w=",
+      "optional": true
     },
     "vinyl": {
       "version": "1.2.0",
@@ -17667,6 +18690,15 @@
         }
       }
     },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "optional": true,
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
     "widest-line": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
@@ -17951,6 +18983,11 @@
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
     },
+    "xregexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+      "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
+    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
@@ -17970,8 +19007,7 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -41,11 +41,13 @@
   "dependencies": {
     "@frctl/fractal": "^1.1.4",
     "@stencil/core": "^0.11.4",
+    "@types/d3-fetch": "^1.1.2",
     "@types/geojson": "^7946.0.1",
     "@types/jest": "^22.1.1",
     "@types/leaflet": "^1.2.5",
     "autoprefixer": "^6.7.7",
     "concurrently": "^3.5.1",
+    "d3-fetch": "^1.1.2",
     "esri-leaflet": "^2.2.3",
     "esri-leaflet-geocoder": "^2.2.13",
     "gulp": "^3.9.1",
@@ -67,7 +69,10 @@
     "rucksack-css": "^0.9.1",
     "run-sequence": "^1.2.2",
     "serve-static": "^1.11.1",
-    "templayed": "github:CityOfBoston/templayed.js"
+    "templayed": "github:CityOfBoston/templayed.js",
+    "vega": "^4.2.0",
+    "vega-lite": "^3.0.0-rc5",
+    "vega-tooltip": "^0.13.0"
   },
   "devDependencies": {
     "@types/nock": "^9.1.2",

--- a/web-components/chart/chart.css
+++ b/web-components/chart/chart.css
@@ -1,6 +1,5 @@
 .cob-chart {
-  padding: 20px;
-  padding-bottom: 0px;
+  padding: 20px 20px 0;
 }
 
 .cob-chart-wrapper {
@@ -10,7 +9,7 @@
 #vg-tooltip-element .value,
 h2 {
   text-transform: uppercase;
-  font-family: 'Montserrat';
+  font-family: 'Montserrat', Arial, sans-serif;
   font-size: 14px;
 }
 
@@ -20,8 +19,8 @@ h2 {
 }
 
 #vg-tooltip-element .key {
-  font-family: 'Lora';
-  font-style: 'italic';
+  font-family: 'Lora', Georgia, serif;
+  font-style: italic;
   font-size: 16px;
   border-radius: 0;
 }

--- a/web-components/chart/chart.css
+++ b/web-components/chart/chart.css
@@ -1,0 +1,27 @@
+.cob-chart {
+  padding: 20px;
+  padding-bottom: 0px;
+}
+
+.cob-chart-wrapper {
+  overflow-x: scroll;
+}
+
+#vg-tooltip-element .value,
+h2 {
+  text-transform: uppercase;
+  font-family: 'Montserrat';
+  font-size: 14px;
+}
+
+#vg-tooltip-element h2 {
+  font-size: 16px;
+  font-weight: bold;
+}
+
+#vg-tooltip-element .key {
+  font-family: 'Lora';
+  font-style: 'italic';
+  font-size: 16px;
+  border-radius: 0;
+}

--- a/web-components/chart/chart.tsx
+++ b/web-components/chart/chart.tsx
@@ -240,7 +240,7 @@ export class CobChart {
   // This currently supports only one selection that is a dropdown/select element.
   buildDropDownSelection() {
     // We grab the div holding the chart and selection elements.
-    const selectDiv = this.el.querySelector('div');
+    const selectDiv = document.getElementById(this.chartID)!;
 
     // We create a div for the blue drop down arrow and assign it the
     // proper classes from Fleet.
@@ -248,7 +248,7 @@ export class CobChart {
     selectArrow.className = 'sel-c sel-c--fw';
 
     // We grab the parent element we'll append the arrow to and add it.
-    const selectParent = selectDiv.querySelector('.vega-bind');
+    const selectParent = selectDiv.querySelector('.vega-bind')!;
     selectParent.appendChild(selectArrow);
 
     // Vega creates a unique identifier for the select element by appending "select"
@@ -256,12 +256,12 @@ export class CobChart {
     const selectName = 'select_' + this.selectField;
 
     // Grab the select element and append it to the arrow div
-    const selectElem = selectDiv.querySelector('select');
+    const selectElem = selectDiv.querySelector('select')!;
     selectElem.className = 'sel-f';
     selectArrow.appendChild(selectElem);
 
     // Update the classes for the select label
-    const selectLabel = selectDiv.querySelector('.vega-bind-name');
+    const selectLabel = selectDiv.querySelector('.vega-bind-name')!;
     selectLabel.className = 'sel-l sel-l--mt000';
 
     // So that the chart loads with a selection set, we filter the data onload.

--- a/web-components/chart/chart.tsx
+++ b/web-components/chart/chart.tsx
@@ -1,0 +1,306 @@
+import { Component, Prop, Listen, Element } from '@stencil/core';
+import * as Vega from 'vega';
+import * as VegaLite from 'vega-lite';
+import vegaTooltip from 'vega-tooltip';
+import { csv as d3csv } from 'd3-fetch';
+
+@Component({
+  tag: 'cob-chart',
+  styleUrl: 'chart.css',
+})
+export class CobChart {
+  @Element() el;
+
+  @Prop({ mutable: true })
+  config: any;
+  chartID: string = '';
+  minWidth: number = 0;
+  view: any;
+  compiledSpec: any;
+  dataset: any;
+  selectField: string = '';
+  selectOptions: any;
+  vegaLite: boolean = true;
+
+  // We listen for a window resize and adjust the width of the chart if it happens
+  @Listen('window:resize')
+  setChartWidth() {
+    // We use the chart div to set the width of the svg chart element and
+    // subtract 50px from it to account for padding.
+    const newWidth = this.el.getBoundingClientRect().width - 50;
+
+    // We don't want our chart's width to be less than the minWidth,
+    // so if the new wrapper div width is less than that, we set it
+    // manually.
+    this.view.width(newWidth >= this.minWidth ? newWidth : this.minWidth).run();
+
+    // If we're using vega and we're specifically building a pie chart then
+    // we want to make sure the width of the chart doesn't exceed the height
+    // to prevent the pie from getting cut off.
+    if (
+      this.vegaLite == false &&
+      this.config.marks.filter(item => item.type == 'arc').length >= 1
+    ) {
+      // In this case we have a max width which is the given height of the chart
+      const maxWidth = this.config.height;
+      this.view.width(newWidth >= maxWidth ? maxWidth : newWidth).run();
+    }
+
+    // We can't use "autosize" on facet charts in Vega, so if we're using columns
+    // we update the "child_width" and "child_height" signals to update
+    // the size of the chart.
+    if (
+      this.vegaLite == true &&
+      typeof this.config.encoding.column !== 'undefined'
+    ) {
+      /* The "width" in facet/grouped charts refers to the width of 
+        each column in the chart, so we:
+        1. calculate the number of columns in the chart
+        2. get the width of the y-axis
+        3. calculate the appropriate width for each column
+      */
+
+      // We get number of columns in the chart by calucating the unique
+      // values in the field being used to group the data.
+      const field = this.config.encoding.column.field;
+      const numColumns = [...new Set(this.dataset.map(item => item[field]))]
+        .length;
+
+      // We get the width of the y-axis so we can make sure the new
+      // width has enough room for it.
+      const yAxis = this.el.getElementsByClassName(
+        'mark-group role-row-header row_header'
+      )[0];
+      const yAxisWidth = yAxis.getBoundingClientRect().width;
+
+      // We get the width of the chart container to understand how much
+      // room we have to work with.
+      const containerDivWidth = this.el.getBoundingClientRect().width;
+
+      // We calculate what the new width would be we also calculate what
+      // what the smallest calculated width should be based on the minWidth
+      // provided by the schema.
+      const calcWidth = containerDivWidth / numColumns - yAxisWidth;
+      const calcMinWidth = this.minWidth / numColumns - yAxisWidth;
+
+      // If the new calculated width is larger than the calculated min width,
+      // we're good to go, if it is smaller, we use the calculated min width.
+      const newWidth = calcWidth > calcMinWidth ? calcWidth : calcMinWidth;
+
+      // We pass the new width to the chart's 'child_width' signal
+      this.view.signal('child_width', newWidth);
+
+      /* To make sure we have enough room for the legend at this new window size,
+      we also calculate a new chart height by:
+        1. finding the height of the legend
+        2. subtracting the legend height from the total height provided in the schema
+        3. updating the 'child_height' signal with the new height
+      */
+      const legend = this.el.getElementsByClassName(
+        'mark-group role-legend'
+      )[0];
+      const legendHeight = legend.getBoundingClientRect().height;
+      const calcHeight = this.config.height - legendHeight;
+      this.view.signal('child_height', calcHeight);
+
+      /* Finally, we update the width and height of the svg element the chart is 
+      sitting in to make sure the viewbox proportions stay the same and the chart
+      sits nicely on the page.
+      We do this by:
+        1. getting the chart svg element
+        2. grabbing its height
+        3. setting the correct width of the chart svg
+        4. updating the viewbox with our new numbers
+      */
+      const chartSVG = this.el.children[1].children[0].children[0];
+
+      const chartSvgHeight = chartSVG.getBoundingClientRect().height;
+      // If we're using the min width, we also use it to set the new svg width. If we're using
+      // the calculated with, we use the width of the container div and subtract
+      // 40px from it. We do this to account for 20px of padding we put around
+      // the chart.
+      const chartSvgWidth =
+        calcWidth > calcMinWidth ? containerDivWidth - 40 : this.minWidth;
+
+      // We set the width of the svg to our new width
+      chartSVG.setAttribute('width', `${chartSvgWidth}`);
+      // We update the viewbox attribute as well so the chart fits nicely into the
+      // svg element.
+      chartSVG.setAttribute(
+        'viewBox',
+        `0 0 ${chartSvgWidth} ${chartSvgHeight}`
+      );
+
+      // After everything is calculated, we re-draw the view
+      this.view.run();
+    }
+  }
+
+  async componentWillLoad() {
+    // We grab the config and set variables we'll use later
+    this.config = this.getConfig();
+    this.vegaLite = this.config.$schema.includes('vega-lite') ? true : false;
+    this.chartID = this.config.boston.chartID;
+    this.minWidth =
+      // minWidth is a custom variable we've added into the "boston"
+      // section of the vega schema, we set it to 0 if it wasn't provided
+      typeof this.config.boston.minWidth !== 'undefined'
+        ? this.config.boston.minWidth
+        : 0;
+
+    // We check to see if we're using vega or vega-lite because pie charts require
+    // the vega schema, while all other charts are built with vega-lite.
+    if (this.vegaLite == true) {
+      // If we are using vegaLite, we load the data from the provided url.
+      const data = await d3csv(this.config.data.url);
+      this.dataset = data;
+      this.config.data.values = this.dataset;
+      this.config.data.url = '';
+
+      // We check to see if this chart uses interactive selections.  If yes,
+      // we figure out the list of options and populate the dropdown menu.
+      if (typeof this.config.selection == 'undefined') {
+        // If we are not using them, we compile the given config to vega
+        // and create a vega view.
+        this.compiledSpec = VegaLite.compile(this.config);
+        this.view = new Vega.View(Vega.parse(this.compiledSpec.spec)).renderer(
+          'svg'
+        );
+      } else {
+        // If we are using a selection, we get an array of the unique values in the
+        // chosen field to use to populate the dropwdown menu.
+        this.selectField = this.config.selection.select.fields[0];
+        this.selectOptions = [
+          ...new Set(this.dataset.map(item => item[this.selectField])),
+        ].sort();
+
+        // We update the config to reflect the unique values we just found
+        this.config.selection.select.bind.options = this.selectOptions;
+
+        // After updating the config, we compile it to Vega and parse it
+        this.compiledSpec = VegaLite.compile(this.config);
+
+        /* By default Vega adds and event listener to our selection that 
+          fires when the chart is clicked. The click sets the selection
+          back to null, so the user's selection gets undone. 
+
+          To get around this, we remove the event listener configuration 
+          from the compiled Vega spec.
+        */
+        const selectSignal = this.compiledSpec.spec.signals.find(
+          elem => elem.name === `select_${this.selectField}`
+        );
+        delete selectSignal.on;
+
+        // After updating the spec and compiling it, we create a new Vega view
+        // for the chart.
+        this.view = new Vega.View(Vega.parse(this.compiledSpec.spec)).renderer(
+          'svg'
+        );
+      }
+    } else {
+      // If we aren't using vegaLite, we don't need to compile the config, so we set
+      // this.compiledSpec to be the same as this.config and create the view object.
+      this.compiledSpec = this.config;
+      this.view = new Vega.View(Vega.parse(this.compiledSpec)).renderer('svg');
+    }
+  }
+
+  componentDidLoad() {
+    // Once the component loads, we initialize the view.
+    this.view.initialize(`#${this.chartID}`);
+    // Attach tooltips to the chart
+    vegaTooltip(this.view);
+
+    // If we are using selections, we build the dropdown.
+    if (this.config.selection) {
+      this.buildDropDownSelection();
+    }
+
+    // We wrap the chart svg inside a div so we can control horizontal scrolling
+    // for just the chart and not any elements around or below.
+    const chartWrapper = document.createElement('div');
+    chartWrapper.className = 'cob-chart-wrapper';
+    // Get the chart svg element and its parent node
+    const chartSVG = this.el.children[1].children[0];
+    const svgParent = chartSVG.parentNode;
+    // Update the children of the parent node
+    svgParent.replaceChild(chartWrapper, chartSVG);
+    chartWrapper.appendChild(chartSVG);
+
+    // Lastly, we set that chart width on load so we can
+    // make sure it fits nicely into the page.
+    this.setChartWidth();
+  }
+
+  // We custom build the dropdown selection to adhere to our styles and branding.
+  // This currently supports only one selection that is a dropdown/select element.
+  buildDropDownSelection() {
+    // We grab the div holding the chart and selection elements.
+    const selectDiv = this.el.children[1];
+
+    // We create a div for the blue drop down arrow and assign it the
+    // proper classes from Fleet.
+    const selectArrow = document.createElement('div');
+    selectArrow.className = 'sel-c sel-c--fw';
+
+    // We grab the parent element we'll append the arrow to and add it.
+    const selectParent = selectDiv.querySelector('.vega-bind');
+    selectParent.appendChild(selectArrow);
+
+    // Vega creates a unique identifier for the select element by appending "select"
+    // and the name of the field used for the selection, so we do the same to access it.
+    const selectName = 'select_' + this.selectField;
+
+    // Grab the select element and append it to the arrow div
+    const selectElem = selectDiv.querySelector('select');
+    selectElem.className = 'sel-f';
+    selectArrow.appendChild(selectElem);
+
+    // Update the classes for the select label
+    const selectLabel = selectDiv.querySelector('.vega-bind-name');
+    selectLabel.className = 'sel-l sel-l--mt000';
+
+    // So that the chart loads with a selection set, we filter the data onload.
+    // Grab the option that is selected
+    const selected = selectElem.selectedIndex;
+
+    // Update the select signal and re-render the chart
+    this.view.signal(selectName, this.selectOptions[selected]).run();
+
+    // Everytime the selection changes, we want to make sure the the chart still fits
+    // nicely on the page.
+    selectElem.addEventListener('change', () => {
+      this.setChartWidth();
+    });
+  }
+
+  /**
+   * Takes JSON out of either a "config" prop or a <script> child. We support
+   * the former for integration with other components, and the latter for easier
+   * HTML building.
+   */
+  getConfig(): any | null {
+    // Get JSON from web component config slot
+    // The JSON config schema comes from Vega/VegaLite (https://vega.github.io/vega/)
+    const configScript = this.el.querySelector('script[slot="config"]');
+
+    try {
+      if (this.config) {
+        return JSON.parse(this.config);
+      } else if (configScript) {
+        return JSON.parse(configScript.innerHTML);
+      } else {
+        return null;
+      }
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error('Could not parse config JSON', e);
+      throw e;
+    }
+  }
+
+  render() {
+    return <div class="cob-chart" id={this.chartID} />;
+  }
+}

--- a/web-components/chart/readme.md
+++ b/web-components/chart/readme.md
@@ -1,0 +1,17 @@
+# my-first-component
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property | Attribute | Description | Type  |
+| -------- | --------- | ----------- | ----- |
+| `config` | --        |             | `any` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/web-components/components.d.ts
+++ b/web-components/components.d.ts
@@ -24,6 +24,10 @@ declare global {
 
   namespace StencilComponents {
 
+    interface CobChart {
+      'config': any;
+    }
+
     interface CobContactForm {
       /**
        * Defaults to `https://contactform.boston.gov/emails` but can be set for development testing.
@@ -88,6 +92,14 @@ declare global {
   }
 
 
+    interface HTMLCobChartElement extends StencilComponents.CobChart, HTMLStencilElement {}
+
+    var HTMLCobChartElement: {
+      prototype: HTMLCobChartElement;
+      new (): HTMLCobChartElement;
+    };
+    
+
     interface HTMLCobContactFormElement extends StencilComponents.CobContactForm, HTMLStencilElement {}
 
     var HTMLCobContactFormElement: {
@@ -107,12 +119,17 @@ declare global {
   namespace JSX {
     interface Element {}
     export interface IntrinsicElements {
+    'cob-chart': JSXElements.CobChartAttributes;
     'cob-contact-form': JSXElements.CobContactFormAttributes;
     'cob-map': JSXElements.CobMapAttributes;
     }
   }
 
   namespace JSXElements {
+
+    export interface CobChartAttributes extends HTMLAttributes {
+      'config'?: any;
+    }
 
     export interface CobContactFormAttributes extends HTMLAttributes {
       /**
@@ -158,11 +175,13 @@ declare global {
   }
 
   interface HTMLElementTagNameMap {
+    'cob-chart': HTMLCobChartElement
     'cob-contact-form': HTMLCobContactFormElement
     'cob-map': HTMLCobMapElement
   }
 
   interface ElementTagNameMap {
+    'cob-chart': HTMLCobChartElement;
     'cob-contact-form': HTMLCobContactFormElement;
     'cob-map': HTMLCobMapElement;
   }

--- a/web-components/html/bar-chart-select.html
+++ b/web-components/html/bar-chart-select.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
+  <title>Chart</title>
+
+  <!--[if !IE]><!-->
+  <link rel="stylesheet" type="text/css" href="/css/public.css" />
+  <!--<![endif]-->
+  <!--[if lt IE 10]>
+    <link media="all" rel="stylesheet" href="/css/ie.css">
+  <![endif]-->
+
+</head>
+
+<body>
+  <cob-chart>
+    <script type="application/json" slot="config">
+        {
+            "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+            "boston": {
+              "minWidth": 500,
+              "chartID": "barChart1"
+            },
+            "title": {
+              "text": "FY19 Spending by Cabinet",
+              "anchor": "start"
+            },
+            "description": "A simple bar chart with embedded data.",
+            "width": 500,
+            "height": 500,
+            "autosize": "fit",
+            "selection": {
+              "select": {
+                "type": "single",
+                "fields": ["cabinet"],
+                "bind": {"input": "select", 
+                       "element": "#select", 
+                       "options": ["Kayla"],
+                       "name": "Select a cabinet: "}
+              }
+            },
+            "data": {
+                "name": "data",
+                "url": "https://gist.githubusercontent.com/paylakatel/03df34fe8d74e22c5ed3f1f178305423/raw/fe4a8ffa72098646b87eb041607c4e92be68c452/testData.csv"
+              },
+            "transform": [
+                {"filter": {"selection": "select"}}
+              ],
+            "mark": "bar",
+            "encoding": {
+              "color": { "value": "#45789C"},
+              "y": {"field": "dept", "type": "nominal", 
+                  "sort": {"op": "sum", "field": "budget", "order": "descending"},
+                  "axis": {"title": "" }},
+              "x": {"aggregate": "sum", "field": "budget", "type": "quantitative",
+                "axis": {"title": "FY19 Budget", "grid": true}}
+            },
+            "config": {
+              "numberFormat": "s",
+              "title": {
+                "font": "Montserrat",
+                "fontSize": 20
+              },
+              "axis": {
+                "labelFont": "Lora",
+                "labelFontSize": 16,
+                "labelLimit": 500,
+                "titleFont": "Montserrat",
+                "titleFontSize": 16,
+                "titleFontWeight": "normal",
+                "titlePadding": 15
+              }
+            }
+          }
+        </script>
+  </cob-chart>
+
+  <script src="/web-components/fleetcomponents.js"></script>
+</body>
+
+</html>

--- a/web-components/html/bar-chart.html
+++ b/web-components/html/bar-chart.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
+  <title>Chart</title>
+
+  <!--[if !IE]><!-->
+  <link rel="stylesheet" type="text/css" href="/css/public.css" />
+  <!--<![endif]-->
+  <!--[if lt IE 10]>
+    <link media="all" rel="stylesheet" href="/css/ie.css">
+  <![endif]-->
+
+</head>
+
+<body>
+  <cob-chart>
+    <script type="application/json" slot="config">
+        {
+          "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+          "boston": {
+            "chartID": "barChart",
+            "minWidth": 600
+          },
+          "title": {
+            "text": "FY19 Spending by Cabinet",
+            "anchor": "start"
+          },
+          "description": "A simple bar chart with embedded data.",
+          "height": 600,
+          "autosize": "fit",
+          "data": { "url": "https://gist.githubusercontent.com/paylakatel/03df34fe8d74e22c5ed3f1f178305423/raw/fe4a8ffa72098646b87eb041607c4e92be68c452/testData.csv"},
+          "mark": "bar",
+          "encoding": {
+            "color": { "value": "#45789C"},
+            "y": {"field": "cabinet", "type": "nominal", 
+                "sort": {"op": "sum", "field": "budget", "order": "descending"},
+                "axis": {"title": "" }},
+            "x": {"aggregate": "sum", "field": "budget", "type": "quantitative",
+              "axis": {"title": "FY19 Budget", "grid": true}}
+          },
+          "config": {
+            "numberFormat": "s",
+            "title": {
+              "font": "Montserrat",
+              "fontSize": 20
+            },
+            "axis": {
+              "labelFont": "Lora",
+              "labelFontSize": 16,
+              "labelLimit": 500,
+              "titleFont": "Montserrat",
+              "titleFontSize": 16,
+              "titleFontWeight": "normal",
+              "titlePadding": 15
+            }
+          }
+        }
+        </script>
+  </cob-chart>
+
+  <script src="/web-components/fleetcomponents.js"></script>
+</body>
+
+</html>

--- a/web-components/html/grouped-bar-chart-select.html
+++ b/web-components/html/grouped-bar-chart-select.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
+  <title>Chart</title>
+
+  <!--[if !IE]><!-->
+  <link rel="stylesheet" type="text/css" href="/css/public.css" />
+  <!--<![endif]-->
+  <!--[if lt IE 10]>
+    <link media="all" rel="stylesheet" href="/css/ie.css">
+  <![endif]-->
+
+</head>
+
+<body>
+  <cob-chart>
+    <script type="application/json" slot="config">
+            {
+                "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+                "boston": {
+                  "chartID": "groupedBarSelect1",
+                  "minWidth": 500
+                },
+                "title": {
+                  "text": "Fake data by budget year",
+                  "anchor": "start"
+                },
+                "description": "A simple bar chart with embedded data.",
+                "height": 400,
+                "width": 10,
+                "selection": {
+                  "select": {
+                    "type": "single",
+                    "fields": ["dept"],
+                    "bind": {"input": "select", 
+                             "element": "#select", 
+                             "options": ["Mayor's Office", "Neighborhood Services"],
+                             "name": "Select a Department: "}
+                      }
+                    },
+                "data": {
+                    "name": "data",
+                    "url": "https://gist.githubusercontent.com/paylakatel/03df34fe8d74e22c5ed3f1f178305423/raw/fe4a8ffa72098646b87eb041607c4e92be68c452/testData.csv"
+                  },
+                "transform": [
+                  {"filter": {"selection": "select"}}
+                ],
+                "mark": {
+                  "type": "bar"
+                  },
+                "encoding": {
+                  "column": {
+                    "field": "year",
+                    "type": "ordinal",
+                    "title": "",
+                    "header":{
+                      "labelFontSize": 14,
+                      "labelFont": "Lora"
+                      }
+                    },
+                  "color": { 
+                    "field": "program", 
+                    "type": "nominal",
+                    "legend": {
+                      "orient": "bottom",
+                      "labelFont": "Lora",
+                      "labelFontSize": 16,
+                      "labelLimit": 500,
+                      "titleFont": "Montserrat",
+                      "title": ""
+                      }
+                    },
+                  "y": {"field": "budget", "type": "quantitative", 
+                      "axis": {"title": "" }},
+                  "x": {
+                    "field": "program", 
+                    "type": "nominal",
+                    "sort": {"op": "sum", "field": "budget", "order": "descending"},
+                    "axis": {
+                      "title": "", 
+                      "grid": false,
+                      "labels": false,
+                      "ticks": false
+                      }
+                    }
+                },
+                "config": {
+                  "point": {"size": 60},
+                  "numberFormat": "s",
+                  "title": {
+                    "font": "Montserrat",
+                    "fontSize": 20
+                  },
+                  "axis": {
+                    "labelFont": "Lora",
+                    "labelFontSize": 16,
+                    "labelLimit": 500,
+                    "titleFont": "Montserrat",
+                    "titleFontSize": 16,
+                    "titleFontWeight": "normal",
+                    "titlePadding": 15
+                  }
+                }
+              }
+        </script>
+  </cob-chart>
+
+  <script src="/web-components/fleetcomponents.js"></script>
+</body>
+
+</html>

--- a/web-components/html/grouped-bar-chart.html
+++ b/web-components/html/grouped-bar-chart.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
+  <title>Chart</title>
+
+  <!--[if !IE]><!-->
+  <link rel="stylesheet" type="text/css" href="/css/public.css" />
+  <!--<![endif]-->
+  <!--[if lt IE 10]>
+    <link media="all" rel="stylesheet" href="/css/ie.css">
+  <![endif]-->
+
+</head>
+
+<body>
+  <cob-chart>
+    <script type="application/json" slot="config">
+      {
+        "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+        "boston": {
+          "minWidth": 450,
+          "chartID": "groupedBarChart1"
+        },
+        "title": {
+          "text": "City-wide Spending by Year",
+          "anchor": "start"
+        },
+        "description": "A simple bar chart with embedded data.",
+        "width": 50,
+        "height": 500,
+        "data": {
+            "name": "data",
+            "url": "https://gist.githubusercontent.com/paylakatel/dfbc33ad0c17486ca03b49903b0e565d/raw/194cf94a9d5dea0113876d71983daca4896bb2e5/test-budget-data.csv"
+          },
+        "mark": {
+          "type": "bar"
+          },
+        "encoding": {
+          "column": {
+            "field": "Attribute",
+            "type": "ordinal",
+            "title": "",
+            "header":{
+              "labelFontSize": 14,
+              "labelFont": "Lora"
+              }
+            },
+          "color": { 
+            "field": "Type", 
+            "type": "nominal",
+            "legend": {
+              "orient": "bottom",
+              "labelFont": "Lora",
+              "labelFontSize": 16,
+              "labelLimit": 500,
+              "titleFont": "Montserrat",
+              "title": ""
+              }
+            },
+          "y": {"field": "Value", "type": "quantitative", 
+              "axis": {"title": ""},
+              "scale": {"domain": [0,2000000000]}},
+          "x": {
+            "field": "Type", 
+            "type": "nominal",
+            "sort": ["Personnel Services", "Other Expenses", "Contractual Services", "Current Charges & Obligations", "Fixed Expenses", "Equipment", "Supplies & Materials"],
+            "axis": {
+              "title": "", 
+              "grid": false,
+              "labels": false,
+              "ticks": false
+              }
+            }
+        },
+        "config": {
+          "point": {"size": 60},
+          "numberFormat": "s",
+          "title": {
+            "font": "Montserrat",
+            "fontSize": 20
+          },
+          "axis": {
+            "labelFont": "Lora",
+            "labelFontSize": 16,
+            "labelLimit": 500,
+            "titleFont": "Montserrat",
+            "titleFontSize": 16,
+            "titleFontWeight": "normal",
+            "titlePadding": 15
+          }
+        }
+      }
+        </script>
+  </cob-chart>
+
+  <script src="/web-components/fleetcomponents.js"></script>
+</body>
+
+</html>

--- a/web-components/html/grouped-bar-chart.html
+++ b/web-components/html/grouped-bar-chart.html
@@ -33,7 +33,7 @@
         "height": 500,
         "data": {
             "name": "data",
-            "url": "https://gist.githubusercontent.com/paylakatel/dfbc33ad0c17486ca03b49903b0e565d/raw/194cf94a9d5dea0113876d71983daca4896bb2e5/test-budget-data.csv"
+            "url": "https://gist.githubusercontent.com/paylakatel/dfbc33ad0c17486ca03b49903b0e565d/raw/f1861707b95c5db065dc7d25c3c21a7fca76bc1b/test-budget-data.csv"
           },
         "mark": {
           "type": "bar"

--- a/web-components/html/line-chart-select.html
+++ b/web-components/html/line-chart-select.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
+  <title>Chart</title>
+
+  <!--[if !IE]><!-->
+  <link rel="stylesheet" type="text/css" href="/css/public.css" />
+  <!--<![endif]-->
+  <!--[if lt IE 10]>
+    <link media="all" rel="stylesheet" href="/css/ie.css">
+  <![endif]-->
+
+</head>
+
+<body>
+  <cob-chart>
+    <script type="application/json" slot="config">
+            {
+                "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+                "boston": {
+                  "chartID": "lineChartSelect"
+                },
+                "title": {
+                  "text": "Fake data by year",
+                  "anchor": "start"
+                },
+                "description": "A simple bar chart with embedded data.",
+                "width": 500,
+                "height": 500,
+                "autosize": "fit",
+                "data": {
+                    "name": "data",
+                    "url": "https://gist.githubusercontent.com/paylakatel/199c61b8a60d5053cd5c8e1074a0b458/raw/434831dcd936b048d8a12ea792d22b4c9679d6c2/year-data.csv"
+                  },
+                "transform": [
+                    {"filter": {"selection": "select"}}
+                ],
+                "mark": {
+                  "type": "line", 
+                  "point": true
+                  },
+                "selection": {
+                  "select": {
+                    "type": "single",
+                    "fields": ["group"],
+                    "bind": {"input": "select", 
+                           "element": "#select", 
+                           "options": ["Low Income", "Middle Income", "Total"],
+                           "name": "Select a cabinet: "}
+                  }
+                },
+                "encoding": {
+                  "color": { "value": "#45789C"},
+                  "y": {"field": "amount", "type": "quantitative", 
+                      "sort": {"op": "sum", "field": "amount", "order": "descending"},
+                      "axis": {"title": "" }},
+                  "x": {"field": "year", "type": "temporal",
+                    "axis": {"title": "FY19 Budget", "grid": true}}
+                },
+                "config": {
+                  "point": {"size": 60},
+                  "numberFormat": "s",
+                  "title": {
+                    "font": "Montserrat",
+                    "fontSize": 20
+                  },
+                  "axis": {
+                    "labelFont": "Lora",
+                    "labelFontSize": 16,
+                    "labelLimit": 500,
+                    "titleFont": "Montserrat",
+                    "titleFontSize": 16,
+                    "titleFontWeight": "normal",
+                    "titlePadding": 15
+                  }
+                }
+              }
+        </script>
+  </cob-chart>
+
+  <script src="/web-components/fleetcomponents.js"></script>
+</body>
+
+</html>

--- a/web-components/html/line-chart.html
+++ b/web-components/html/line-chart.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
+  <title>Chart</title>
+
+  <!--[if !IE]><!-->
+  <link rel="stylesheet" type="text/css" href="/css/public.css" />
+  <!--<![endif]-->
+  <!--[if lt IE 10]>
+    <link media="all" rel="stylesheet" href="/css/ie.css">
+  <![endif]-->
+
+</head>
+
+<body>
+  <cob-chart>
+    <script type="application/json" slot="config">
+            {
+                "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+                "boston": {
+                  "chartID": "simpleLineChart"
+                },
+                "title": {
+                  "text": "Fake data by year",
+                  "anchor": "start"
+                },
+                "description": "A simple bar chart with embedded data.",
+                "width": 500,
+                "height": 500,
+                "autosize": {"type": "fit", 
+                             "resize": "true"},
+                "data": {
+                    "name": "data",
+                    "url": "https://gist.githubusercontent.com/paylakatel/199c61b8a60d5053cd5c8e1074a0b458/raw/434831dcd936b048d8a12ea792d22b4c9679d6c2/year-data.csv"
+                  },
+                "mark": {"type": "line", "point": true},
+                "encoding": {
+                  "color": { "field": "group", 
+                    "type": "nominal",
+                    "legend": {
+                      "orient": "bottom",
+                      "labelFont": "Lora",
+                      "labelFontSize": 16,
+                      "titleFont": "Montserrat",
+                      "title": ""
+                      }},
+                  "y": {"field": "amount", "type": "quantitative", 
+                      "sort": {"op": "sum", "field": "amount", "order": "descending"},
+                      "axis": {"title": "" }},
+                  "x": {"field": "year", "type": "temporal",
+                    "axis": {"title": "FY19 Budget", "grid": true}}
+                },
+                "config": {
+                  "point": {"size": 60},
+                  "numberFormat": "s",
+                  "title": {
+                    "font": "Montserrat",
+                    "fontSize": 20
+                  },
+                  "axis": {
+                    "labelFont": "Lora",
+                    "labelFontSize": 16,
+                    "labelLimit": 500,
+                    "titleFont": "Montserrat",
+                    "titleFontSize": 16,
+                    "titleFontWeight": "normal",
+                    "titlePadding": 15
+                  }
+                }
+              }
+        </script>
+  </cob-chart>
+
+  <script src="/web-components/fleetcomponents.js"></script>
+</body>
+
+</html>

--- a/web-components/html/pie-chart.html
+++ b/web-components/html/pie-chart.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
+  <title>Chart</title>
+
+  <!--[if !IE]><!-->
+  <link rel="stylesheet" type="text/css" href="/css/public.css" />
+  <!--<![endif]-->
+  <!--[if lt IE 10]>
+    <link media="all" rel="stylesheet" href="/css/ie.css">
+  <![endif]-->
+
+</head>
+
+<body>
+  <script id="__bs_script__">//<![CDATA[
+    document.write("<script async src='/browser-sync/browser-sync-client.js?v=2.23.6'><\/script>".replace("HOST", location.hostname));
+//]]></script>
+
+  <cob-chart>
+    <script type="application/json" slot="config">
+        {
+            "$schema": "https://vega.github.io/schema/vega/v4.json",
+            "boston": {
+                "chartID": "pieChart"
+            },
+            "width": 300,
+            "height": 300,
+            "autosize": {
+              "type": "pad",
+              "resize": true
+            },
+            "padding": 0,
+            "data": [
+              {
+                "name": "table",
+                "url": "https://gist.githubusercontent.com/paylakatel/61e80f50ebdfd5dcd368cb1eb926c9e1/raw/95d4e3cb1c15681cefe496b9716035d45605c25b/pieChartData.csv",
+                "format": {
+                  "type": "csv",
+                  "parse": "auto"
+                },
+                "transform": [
+                  {
+                    "type": "pie",
+                    "field": "percent"
+                  }
+                ]
+              }
+            ],
+            "scales": [
+              {
+                "name": "color",
+                "type": "ordinal",
+                "range": {
+                  "scheme": "category20"
+                }
+              }
+            ],
+            "legends": [
+              {
+                "fill": "color",
+                "orient": "bottom",
+                "labelFont": "Lora",
+                "labelLimit": 500,
+                "labelFontSize": 14,
+                "offset": 5
+              }
+            ],
+            "marks": [
+              {
+                "type": "arc",
+                "from": {
+                  "data": "table"
+                },
+                "encode": {
+                  "enter": {
+                    "fill": {
+                      "scale": "color",
+                      "field": "expenditure"
+                    },
+                    "x": {
+                      "signal": "width / 2"
+                    },
+                    "y": {
+                      "signal": "height / 2"
+                    },
+                    "tooltip": {
+                      "signal": "{title: datum.expenditure, 'Budget': datum.percent}"
+                    }
+                  },
+                  "update": {
+                    "startAngle": {
+                      "field": "startAngle"
+                    },
+                    "endAngle": {
+                      "field": "endAngle"
+                    },
+                    "padAngle": 0,
+                    "innerRadius": {"signal": "width/4"},
+                    "outerRadius": {
+                      "signal": "width / 2"
+                    },
+                    "cornerRadius": 0
+                  }
+                }
+              }
+            ]
+          }
+    </script>
+  </cob-chart>
+
+  <script src="/web-components/fleetcomponents.js"></script>
+</body>
+
+</html>

--- a/web-components/html/pie-chart.html
+++ b/web-components/html/pie-chart.html
@@ -16,100 +16,84 @@
 </head>
 
 <body>
-  <script id="__bs_script__">//<![CDATA[
-    document.write("<script async src='/browser-sync/browser-sync-client.js?v=2.23.6'><\/script>".replace("HOST", location.hostname));
-//]]></script>
-
   <cob-chart>
     <script type="application/json" slot="config">
-        {
-            "$schema": "https://vega.github.io/schema/vega/v4.json",
-            "boston": {
-                "chartID": "pieChart"
-            },
-            "width": 300,
-            "height": 300,
-            "autosize": {
-              "type": "pad",
-              "resize": true
-            },
-            "padding": 0,
-            "data": [
-              {
-                "name": "table",
-                "url": "https://gist.githubusercontent.com/paylakatel/61e80f50ebdfd5dcd368cb1eb926c9e1/raw/95d4e3cb1c15681cefe496b9716035d45605c25b/pieChartData.csv",
-                "format": {
-                  "type": "csv",
-                  "parse": "auto"
-                },
-                "transform": [
-                  {
-                    "type": "pie",
-                    "field": "percent"
-                  }
-                ]
-              }
-            ],
-            "scales": [
-              {
-                "name": "color",
-                "type": "ordinal",
-                "range": {
-                  "scheme": "category20"
-                }
-              }
-            ],
-            "legends": [
-              {
-                "fill": "color",
-                "orient": "bottom",
-                "labelFont": "Lora",
-                "labelLimit": 500,
-                "labelFontSize": 14,
-                "offset": 5
-              }
-            ],
-            "marks": [
-              {
-                "type": "arc",
-                "from": {
-                  "data": "table"
-                },
-                "encode": {
-                  "enter": {
-                    "fill": {
-                      "scale": "color",
-                      "field": "expenditure"
-                    },
-                    "x": {
-                      "signal": "width / 2"
-                    },
-                    "y": {
-                      "signal": "height / 2"
-                    },
-                    "tooltip": {
-                      "signal": "{title: datum.expenditure, 'Budget': datum.percent}"
-                    }
-                  },
-                  "update": {
-                    "startAngle": {
-                      "field": "startAngle"
-                    },
-                    "endAngle": {
-                      "field": "endAngle"
-                    },
-                    "padAngle": 0,
-                    "innerRadius": {"signal": "width/4"},
-                    "outerRadius": {
-                      "signal": "width / 2"
-                    },
-                    "cornerRadius": 0
-                  }
-                }
-              }
-            ]
+      {
+        "$schema": "https://vega.github.io/schema/vega/v4.json",
+        "boston": {
+          "chartID": "pieChart"
+        },
+        "width": 300,
+        "height": 300,
+        "autosize": {
+          "type": "pad",
+          "resize": true
+        },
+        "padding": 0,
+        "data": [{
+          "name": "table",
+          "url": "https://gist.githubusercontent.com/paylakatel/61e80f50ebdfd5dcd368cb1eb926c9e1/raw/95d4e3cb1c15681cefe496b9716035d45605c25b/pieChartData.csv",
+          "transform": [{
+            "type": "pie",
+            "field": "percent"
+          }]
+        }],
+        "scales": [{
+          "name": "color",
+          "type": "ordinal",
+          "range": {
+            "scheme": "category20"
           }
-    </script>
+        }],
+        "legends": [{
+          "fill": "color",
+          "orient": "bottom",
+          "labelFont": "Lora",
+          "labelLimit": 500,
+          "labelFontSize": 14,
+          "offset": 5
+        }],
+        "marks": [{
+          "type": "arc",
+          "from": {
+            "data": "table"
+          },
+          "encode": {
+            "enter": {
+              "fill": {
+                "scale": "color",
+                "field": "expenditure"
+              },
+              "x": {
+                "signal": "width / 2"
+              },
+              "y": {
+                "signal": "height / 2"
+              },
+              "tooltip": {
+                "signal": "{title: datum.expenditure, 'Budget': datum.percent}"
+              }
+            },
+            "update": {
+              "startAngle": {
+                "field": "startAngle"
+              },
+              "endAngle": {
+                "field": "endAngle"
+              },
+              "padAngle": 0,
+              "innerRadius": {
+                "signal": "width/4"
+              },
+              "outerRadius": {
+                "signal": "width / 2"
+              },
+              "cornerRadius": 0
+            }
+          }
+        }]
+      }
+        </script>
   </cob-chart>
 
   <script src="/web-components/fleetcomponents.js"></script>


### PR DESCRIPTION
This PR:
- adds a chart web component that renders line/bar/pie charts using stencil and a vega/vegaLite JSON schema. It helps the charts: resize appropriately, adhere to our styling, and support one level of selections/filtering
- adds a series of html files to test/show the charts we can currently support:
     - bar chart, line chart, grouped bar chart, those charts charts with select drop downs, pie/donut charts