### PR TITLE
Adds a "Browser Warning" component

### DIFF
--- a/components/blocks/browser-warning/browser-warning.config.yml
+++ b/components/blocks/browser-warning/browser-warning.config.yml
@@ -1,0 +1,3 @@
+title: Browser Warning
+handle: browser-warning
+status: ready

--- a/components/blocks/browser-warning/browser-warning.hbs
+++ b/components/blocks/browser-warning/browser-warning.hbs
@@ -1,0 +1,7 @@
+<input id="bwarning-cb" type="checkbox" class="bwarning-cb" checked />
+<div class="bwarning-b">
+  <label for="bwarning-cb" class="bwarning-x">x</label>
+  <h3 class="txt-l txt-l--mt000">Browser Warning</h3>
+  You have JavaScript turned off in your browser. This site won’t work
+  right without it.
+</div>

--- a/stylesheets/components/browser-warning/_browser-warning.styl
+++ b/stylesheets/components/browser-warning/_browser-warning.styl
@@ -1,0 +1,43 @@
+/*
+
+   BROWSER WARNING
+
+   Base:
+    bwarning
+
+   Elements:
+    cb = checkbox
+    b  = body
+    x  = close box
+ */
+
+.bwarning
+  &-cb
+    position: fixed
+    left: 0
+    top: -100px
+  
+  &-b
+    border: $border-200 solid $freedom-red
+    padding: $sizing-400
+    display: none
+    position: fixed
+    bottom: 0
+    width: 100%
+    z-index: 1000
+    background: white
+
+    // checkbox menu trick so that this works in <noscript> mode
+    input:checked ~ &
+      display: block
+
+  &-x
+    cursor: pointer
+    position: absolute
+    top: .75rem
+    right: .75rem
+    color: $freedom-red
+    font-size: 1.5rem
+    font-family: $sans
+    line-height: 0.6
+    

--- a/stylesheets/components/browser-warning/base.styl
+++ b/stylesheets/components/browser-warning/base.styl
@@ -1,0 +1,8 @@
+/*
+
+   BROWSER WARNING
+
+*/
+
+@require('*.styl')
+


### PR DESCRIPTION
The component is fixed to the bottom of the window with a red border and
an "X". It uses the checkbox trick to make the X work without
JavaScript.

Designed to be used for "JavaScript is not enabled" and "Unsupported
browser" errors.