### PR TITLE
Switches TestCafe back to Automate mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "testcafe": "npm run build && npm run testcafe.local",
     "testcafe.local": "cross-env TEST_SERVER_URL=http://localhost:3035/ testcafe -a 'http-server -r public -p 3035' -c 3 chrome:headless components/**/*.testcafe.*",
     "testcafe.dev": "testcafe-live remote components/**/*.testcafe.*",
-    "testcafe.ci": "cross-env TEST_SERVER_URL=http://localhost:3035/ testcafe -a 'http-server -r public -p 3035' 'browserstack:edge@17,browserstack:ie@11.0:Windows 8.1,browserstack:safari,browserstack:chrome:Windows 10,browserstack:firefox:Windows 10' components/**/*.testcafe.*",
+    "testcafe.ci": "cross-env BROWSERSTACK_USE_AUTOMATE=1 TEST_SERVER_URL=http://localhost:3035/ testcafe -a 'http-server -r public -p 3035' 'browserstack:edge@17,browserstack:ie@11.0:Windows 8.1,browserstack:safari@11.1,browserstack:chrome:Windows 10,browserstack:firefox:Windows 10' components/**/*.testcafe.*",
     "precommit": "lint-staged",
     "prepush": "jest --clearCache && npm run test"
   },


### PR DESCRIPTION
 - Non-automate was too flaky, browsers timing out
 - Switches Safari back to 11 until the Selenium / Safari bits get
   fixed.