### PR TITLE
Remove prev and next pagination for mobile.

### DIFF
--- a/stylesheets/components/pagination/_paginator.styl
+++ b/stylesheets/components/pagination/_paginator.styl
@@ -29,6 +29,12 @@
     padding: 0
     margin: 0
 
+    &:first-of-type,
+    &:last-of-type
+      .pg-li-i--link
+        @media $media-medium-max
+          display: none;
+
     &:last-child
       border-right: 2px solid $charles-blue
 


### PR DESCRIPTION
This is a revised PR of https://github.com/CityOfBoston/patterns/pull/400

It fixes https://github.com/CityOfBoston/boston.gov-d7/issues/1214