### PR TITLE
Adds a mn-fixed-child class for nav menu

### DIFF
--- a/stylesheets/components/hamburger/_burger.styl
+++ b/stylesheets/components/hamburger/_burger.styl
@@ -73,7 +73,10 @@ adjust-for-menu()
   show-menu()
 
 .brg-tr:checked ~ .mn,
-.brg-tr:checked ~ .mn--full-ie
+.brg-tr:checked ~ .mn--full-ie,
+// Use this when you need a child of .mn to also move when the menu opens,
+// in particular when it’s fixed.
+.brg-tr:checked ~ .mn .mn-fixed-child
   adjust-for-menu()
 
 // :focus-within is here so the menu opens when you tab into its links. It's not
@@ -85,7 +88,8 @@ adjust-for-menu()
   show-menu()
 
 .nv-m:focus-within ~ .mn,
-.nv-m:focus-within ~ .mn--full-ie
+.nv-m:focus-within ~ .mn--full-ie,
+.nv-m:focus-within ~ .mn .mn-fixed-child
   adjust-for-menu()
 
 .brg

--- a/stylesheets/components/main/_main.styl
+++ b/stylesheets/components/main/_main.styl
@@ -17,6 +17,9 @@
   min-width: 100%
   min-height: 100%
 
+  &-fixed-child
+    transition: left 0.2s
+
   & .a11y--content-start
     position: relative
     top: -65px


### PR DESCRIPTION
Necessary to set the left position of fixed children that should move
out of the way of the side hamburger menu. While not setting a left
position for a fixed element should make it start at the mn element’s
left, Safari does not correctly re-position the element when the value
of left is animated.

See CityOfBoston/311#928