### PR TITLE
Allows a custom geocoder for map address search

### DIFF
--- a/web-components/html/city-council.html
+++ b/web-components/html/city-council.html
@@ -66,7 +66,8 @@
         "title": "",
         "placeholder": "Search for your address…",
         "autoPopupDataSourceUid": "0QYJNIqaMzWBtanIvWles",
-        "zoomToResult": true
+        "zoomToResult": true,
+        "geocoderUrl": "https://awsgeo.boston.gov/arcgis/rest/services/Locators/SAM_Address_FH/GeocodeServer"
       }
     }
   ]

--- a/web-components/map/map-1.0.schema.d.ts
+++ b/web-components/map/map-1.0.schema.d.ts
@@ -208,4 +208,8 @@ export interface AddressSearch {
    * If not `null`, will open the popup for the specified layer when the search result is chosen.
    */
   autoPopupDataSourceUid?: null | string;
+  /**
+   * Specify an ArcGIS GeocodeServer URL other than the default ESRI world one.
+   */
+  geocoderUrl?: null | string;
 }

--- a/web-components/map/map-1.0.schema.json
+++ b/web-components/map/map-1.0.schema.json
@@ -460,6 +460,17 @@
             }
           ],
           "description": "If not `null`, will open the popup for the specified layer when the search result is chosen."
+        },
+        "geocoderUrl": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Specify an ArcGIS GeocodeServer URL other than the default ESRI world one."
         }
       }
     },

--- a/web-components/map/map.tsx
+++ b/web-components/map/map.tsx
@@ -21,7 +21,7 @@ import {
 } from 'leaflet';
 
 import { basemapLayer, tiledMapLayer, query as esriQuery } from 'esri-leaflet';
-import { geosearch } from 'esri-leaflet-geocoder';
+import { geosearch, geocodeServiceProvider } from 'esri-leaflet-geocoder';
 
 // This is our fork of Leaflet/Leaflet.markercluster to fix for module-based
 // importing.
@@ -375,6 +375,14 @@ export class CobMap {
 
     if (this.showAddressSearch) {
       const addressSearchControl = geosearch({
+        providers:
+          mapConfig.addressSearch && mapConfig.addressSearch.geocoderUrl
+            ? [
+                geocodeServiceProvider({
+                  url: mapConfig.addressSearch.geocoderUrl,
+                }),
+              ]
+            : undefined,
         expanded: true,
         placeholder:
           (mapConfig.addressSearch && mapConfig.addressSearch.placeholder) ||
@@ -524,7 +532,7 @@ export class CobMap {
     // This clears out an existing hash if one exists. Otherwise we'd be closed
     // but unable to get a hashchange event to re-open.
     if (this.id && window.location.hash === `#${this.id}`) {
-      history.replaceState(null, undefined, ' ');
+      history.replaceState(null, undefined as any, ' ');
     }
   }
 


### PR DESCRIPTION
The default geocoder gives imprecise results, which means that we
sometimes report the wrong City Council district.