### PR TITLE
Adds "btn--br" variant for borders

### DIFF
--- a/components/base/form/button/button.config.yml
+++ b/components/base/form/button/button.config.yml
@@ -2,6 +2,14 @@ title: 'Button'
 handle: button
 status: ready
 variants:
+  - name: 'Bordered'
+    context:
+      theme:
+        - 'br'
+  - name: 'Bordered White'
+    context:
+      theme:
+        - 'br btn--w'
   - name: 'Yellow'
     context:
       theme:

--- a/stylesheets/components/form/_button.styl
+++ b/stylesheets/components/form/_button.styl
@@ -1,6 +1,6 @@
 /*
 
-   Checkboxes
+   Buttons. Use on both <button> and <a> tags.
 
    Base:
     btn
@@ -9,6 +9,9 @@
     c = charles blue
     sb = small block (becomes block on small screens)
 
+
+  We use ":not(:disabled)" in the rules below instead of ":enabled"
+  so that the rules trigger for <a> tags as well as <button>s.
  */
 
 .btn
@@ -38,17 +41,14 @@
   &:visited
     color: white
 
-  &:hover
+  &:hover:not(:disabled)
     background-color: $freedom-red
     color: white
 
   &:disabled
     cursor: default
     background-color: $grey-100
-
-    &:hover
-      background-color: $grey-100
-      color: white
+    color: $grey-300
 
   &--ib
     display: inline-block
@@ -70,13 +70,13 @@
   &--c
     background-color: $charles-blue
 
-    &:hover
+    &:hover:not(:disabled)
       background-color: $freedom-red
 
   &--y
     background-color: $yellow
 
-    &:hover
+    &:hover:not(:disabled)
       background-color: $yellow-hover
       color: white
 
@@ -84,17 +84,18 @@
     background-color: $white
     color: $optimistic-blue
 
-    &:hover
+
+    &:hover:not(:disabled)
       background-color: $optimistic-blue
       color: $white
 
   &--r-hov
-    &:hover
+    &:hover:not(:disabled)
       background-color: $freedom-red
       color: $white
 
   &--w-hov
-    &:hover
+    &:hover:not(:disabled)
       background-color: $white
       color: $freedom-red
 
@@ -103,6 +104,13 @@
 
     @media $media-xlarge
       margin-top: 0
+
+  // With a border
+  &--br
+    border: $border-200 solid $charles-blue
+
+    &:disabled
+      border-color: $grey-300
 
   &--sm
     font-weight: normal


### PR DESCRIPTION
Also:
 - Changes disabled buttons to have gray text instead of white, per
   design
 - Modifies ":hover" styles to only apply on non-disabled cases so that
   we can remove ":hover:disabled" overrides