### PR TITLE
Two button tweaks for registry-certs

### DIFF
--- a/stylesheets/components/form/_button.styl
+++ b/stylesheets/components/form/_button.styl
@@ -58,6 +58,15 @@
     text-align: center
     width: 100%
 
+  @media $media-large-max
+    // "block small" is a block at breakpoints < large. Use this in a grid
+    // to make the button take up full width when things collapse to a single
+    // column, but naturally-sized when there are columns.
+    &--b-sm
+      display: block
+      text-align: center
+      width: 100%
+
   // Button that fills the remaining space in a flex row
   &--row
     flex: 1
@@ -108,6 +117,10 @@
   // With a border
   &--br
     border: $border-200 solid $charles-blue
+
+    &:focus
+      outline: $border-200 solid $optimistic-blue
+      outline-offset: 1px
 
     &:disabled
       border-color: $grey-300


### PR DESCRIPTION
 - Adds a class that makes the button a full-width block only below
   breakpoints (which is when the grid component switches to a single
   column)
 - Puts an optimistic blue outline around bordered buttons