### PR TITLE
Keeps visited white button links from disappearing

### DIFF
--- a/stylesheets/components/form/_button.styl
+++ b/stylesheets/components/form/_button.styl
@@ -93,6 +93,9 @@
     background-color: $white
     color: $optimistic-blue
 
+    &:link
+    &:visited
+      color: $optimistic-blue
 
     &:hover:not(:disabled)
       background-color: $optimistic-blue


### PR DESCRIPTION
If an <a> tag has btn and btn--w classes, we need to make sure its color
is correct for the white background even if it’s been visited.