### PR TITLE
Footer link correction

### DIFF
--- a/stylesheets/components/footer/_footer.styl
+++ b/stylesheets/components/footer/_footer.styl
@@ -47,7 +47,7 @@
       text-transform: uppercase
       text-decoration: none
       font-weight: 500
-      color: $optimistic-blue-light !important
+      color: $optimistic-blue-light
 
       &:hover
         color: $freedom-red-light

--- a/stylesheets/grid/modern/_grid.styl
+++ b/stylesheets/grid/modern/_grid.styl
@@ -69,6 +69,11 @@
   &--12
     lost-column: 12/12
 
+  @media $media-small-max
+    // Only reversed for mobile viewports; useful for maintaining logical source order
+    &.g--mr
+      flex-direction: row-reverse
+
   @media $media-medium
     &--3
       &--m


### PR DESCRIPTION
- corrects an issue with link colors in the footer
- adds a `g--mr` class to reverse order of children in a grid element, limited to mobile viewports