### PR TITLE
Fixes the breakpoint for g--mr

### DIFF
--- a/stylesheets/grid/modern/_grid.styl
+++ b/stylesheets/grid/modern/_grid.styl
@@ -69,7 +69,7 @@
   &--12
     lost-column: 12/12
 
-  @media $media-small-max
+  @media $media-large-max
     // Only reversed for mobile viewports; useful for maintaining logical source order
     &.g--mr
       flex-direction: column-reverse


### PR DESCRIPTION
The default grid switches from side-by-side to one column at the
breakpoint between medium and large.