### PR TITLE
Matches color value to ideo’s recommended palette

### DIFF
--- a/stylesheets/variables/_colors.styl
+++ b/stylesheets/variables/_colors.styl
@@ -15,8 +15,8 @@ $freedom-red-dark = #d22d23
 // can also be used in decorative cases.
 $optimistic-blue-light  = #288be4
 
-// -dark variant should always be used for text links on white.
-$optimistic-blue-dark = #1979cc
+// -dark variant should always be used for text links on white or $grey-000.
+$optimistic-blue-dark = #1871bd
 
 $optimistic-blue-hover = #175182
 $body-text        = #58585b


### PR DESCRIPTION
My bad - I’d put into place the value for dark Optimistic Blue from my initial recommendation, ideo changed it slightly, and I didn’t update it here. Both Freedom Red values match their ideo palette values, so no need for an update on those.