### PR TITLE
Fixe charts select bug

### DIFF
--- a/web-components/chart/chart.tsx
+++ b/web-components/chart/chart.tsx
@@ -224,7 +224,7 @@ export class CobChart {
 
     // To get around this, we remove the event listener configuration
     // from the compiled Vega spec.
-    (this.compiledSpec.signals || []).find(
+    this.selectSignal = (this.compiledSpec.signals || []).find(
       elem => elem.name === `${this.selectName}_${this.selectField}`
     );
     if (this.selectSignal) {


### PR DESCRIPTION
This PR fixes a bug where when a user clicked on any empty space on a chart, the selection they had chosen got undone. Thought we had fixed this before, but realized there was a bug in the code. 😑