### PR TITLE
Changes left rail "word-break" to "word-wrap"

### DIFF
--- a/legacy/public.styl
+++ b/legacy/public.styl
@@ -3041,7 +3041,7 @@ __summary.collapsible {
 .paragraphs-item-group-of-links-grid .links-grid-left-rail a,
 .paragraphs-item-group-of-links-list .links-grid-left-rail a,
 .view-transactions-main-transactions .links-grid-left-rail a {
-    word-break: break-all
+    word-wrap: break-word
 }
 .paragraphs-item-group-of-links-grid .links-grid-field-grid-links,
 .paragraphs-item-group-of-links-grid .links-grid-field-list-links,


### PR DESCRIPTION
word-break causes words to be broken immediately upon reaching the size
of the container, whereas word-wrap: break-word only does that when the
entire word is wider than the container.

Fixes CityOfBoston/boston.gov-d7#1317