### PR TITLE
Legacy CSS Removal: Issue #579 & 601 HERO Image REWORK

### DIFF
--- a/components/blocks/hero-with-strikethrough/hero-with-strikethrough.hbs
+++ b/components/blocks/hero-with-strikethrough/hero-with-strikethrough.hbs
@@ -1,48 +1,51 @@
-{{#if image}}
-<style>
-  .hros {
-    background-image: url({{image.mobile1x}});
-  }
-
-  @media screen and (min-width: 768px) {
-    .hros {
-      background-image: url({{image.tablet1x}});
-    }
-  }
-
-  @media screen and (min-width: 1024px) {
-    .hros {
-      background-image: url({{image.desktop1x}});
-    }
-  }
-
-  @media screen and (min-width: 1200px) {
-    .hros {
-      background-image: url({{image.wide1x}});
-    }
-  }
-</style>
-{{/if}}
-
-<div class="hros{{#if image}}{{#if title}} hros--t{{else}} hros--b{{/if}}{{else}} hros--d{{/if}}">
+<div
+  class="hros{{#if image}}{{#if title}} hros--t{{else}} hros--b{{/if}}{{else}} hros--d{{/if}}"
+>
+  {{#if image}}
+    <img
+      srcset="
+        {{image.mobile1x}} 480w,
+        {{image.tablet1x}} 768w,
+        {{image.desktop1x}} 1024w,
+        {{image.wide1x}} 1200w,
+      "
+      sizes="(max-width: 600px) 480px, 768px, 1024px, 1200px"
+      src="{{image.mobile1x}}"
+      alt="{{title}}"
+      class="hros--img"
+    />
+  {{/if}}
+  
   <div class="hros-c">
     {{#if intro}}
-    <div class="hros-i{{#if home}} hros-i--l{{/if}}"><span></span>{{intro}}<span></span></div>
+      <div class="hros-i{{#if home}} hros-i--l{{/if}}">
+        <span>{{intro}}</span>
+      </div>
     {{/if}}
-    <h1 class="hros-t{{#if home}} hros-t--l{{/if}}">{{title}}</h1>
+    <h1
+      class="hros-t{{#if home}} hros-t--l{{/if}}"
+    >
+      {{title}}
+    </h1>
     {{#if subheader}}
-    <div class="hros-i{{#if home}} hros-i--l{{/if}}{{#if image}} hros-st--w{{/if}}">{{subheader}}</div>
+      <div
+        class="hros-i{{#if home}} hros-i--l{{/if}}{{#if image}} hros-st--w{{/if}}"
+      >
+        {{subheader}}
+      </div>
     {{/if}}
   </div>
 </div>
+
 <div class="intro-content">
   <div class="topic-intro-text-container">
     <div class="intro-text-top">
       <div class="topic-intro-text-content">
-        <div
-          class="intro-text">
+        <div class="intro-text">
           <p>{{intro-text}}</p>
-          <div class="supporting-text">{{supporting-text}}
+          
+          <div class="supporting-text">
+            {{supporting-text}}
           </div>
         </div>
       </div>

--- a/components/blocks/hero/hero.hbs
+++ b/components/blocks/hero/hero.hbs
@@ -1,30 +1,21 @@
-{{#if image}}
-  <style>
-    .hro {
-      background-image: url({{image.mobile1x}});
-    }
+<div
+  class="hro{{#if image}}{{#if title}} hro--t{{else}} hro--b{{/if}}{{else}} hro--d{{/if}}"
+>
+  {{#if image}}
+    <img
+      srcset="
+        {{image.mobile1x}} 480w,
+        {{image.tablet1x}} 768w,
+        {{image.desktop1x}} 1024w,
+        {{image.wide1x}} 1200w,
+      "
+      sizes="(max-width: 600px) 480px, 768px, 1024px, 1200px"
+      src="{{image.mobile1x}}"
+      alt="{{title}}"
+      class="hro--img"
+    />
+  {{/if}}
 
-    @media screen and (min-width: 768px) {
-      .hro {
-        background-image: url({{image.tablet1x}});
-      }
-    }
-
-    @media screen and (min-width: 1024px) {
-      .hro {
-        background-image: url({{image.desktop1x}});
-      }
-    }
-
-    @media screen and (min-width: 1200px) {
-      .hro {
-        background-image: url({{image.wide1x}});
-      }
-    }
-  </style>
-{{/if}}
-
-<div class="hro{{#if image}}{{#if title}} hro--t{{else}} hro--b{{/if}}{{else}} hro--d{{/if}}">
   <div class="hro-c">
     {{#if intro}}
       <div class="hro-i{{#if home}} hro-i--l{{/if}}">{{intro}}</div>
@@ -38,6 +29,7 @@
       {{/if}}
     {{/if}}
   </div>
+
   {{#if b}}
     <div class="the-b the-b--c">
       <img src="/images/b-light.svg" alt="B Logo" class="the-b-i">

--- a/stylesheets/components/hero-with-strikethrough/_hero-with-strikethrough.styl
+++ b/stylesheets/components/hero-with-strikethrough/_hero-with-strikethrough.styl
@@ -20,14 +20,31 @@
     hm = hide on mobile
  */
 
+.hro
+  &--img
+    position: absolute;
+    top: 0;
+    left: 50%;
+    margin-left: -50%;
+    z-index: 0;
+    width: 100%;
+    height: 100%;
+
 .hros
   text-align: center
-  background-repeat: no-repeat
-  background-size: cover
-  background-position: center
   position: relative
   padding-bottom: 4rem
   border-bottom: 8px solid black
+  overflow: hidden
+
+  &--img
+    position: absolute
+    top: 0
+    left: 50%
+    z-index: 0
+    margin-left: -50%
+    width: 100%
+    height: 100%
 
   &--pt
     padding-top: 3.5rem // The height of Boston.gov header
@@ -50,8 +67,11 @@
   &--d
     background: repeating-linear-gradient(-45deg, $hero-alt, $hero-alt 3px, $hero-main 3px, $hero-main 30px)
     background-size: 42px 42px
+    position: relative
 
   &--t
+    position: relative
+    
     &:after
       content: ''
       position: absolute


### PR DESCRIPTION
Hero and Hero with strikethrough text

- Replaced style tag with media queries for each image sizes with an image tag that uses the `source-set | srcset` attribute to set breakpoint images.
- Added a couple of classes to be used with the image tags with `source-sets | srcset` attributes that will absolutely position them within their container.
- Updated the containers for these images to use `position: relative`
