### PR TITLE
Patch: gem installing faraday to fix Travis issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ branches:
     - production
 install:
   - npm install
+  - gem install faraday -v 1.8.0
   - gem install percy-cli
 before_script:
   - export TZ=America/New_York


### PR DESCRIPTION
Travis (Ruby) build now requires a high version of faraday, this upgrades it to the specified version in the error log.

```bash
ERROR:  Error installing percy-cli:
	The last version of faraday (>= 0.9) to support your Ruby & RubyGems was 1.8.0. Try installing it with `gem install faraday -v 1.8.0` and then running the current command again
	faraday requires Ruby version >= 2.6. The current ruby version is 2.5.3.105.
```