### PR TITLE
(develop) Navigation Bar and Next Button behavior is aligned DIG-4059

### DIFF
--- a/components/base/modal/modal.config.yml
+++ b/components/base/modal/modal.config.yml
@@ -1,0 +1,3 @@
+title: Modal
+handle: md
+status: ready

--- a/components/base/modal/modal.hbs
+++ b/components/base/modal/modal.hbs
@@ -1,0 +1,10 @@
+<div role="dialog">
+  <div class="md">
+    <div class="md-c">
+      <button class="md-cb">Close</button>
+      <div class="mb-b p-a300 p-a600--xl">
+        Modal Content ...
+      </div>
+    </div>
+  </div>
+</div>

--- a/stylesheets/components/form/_textbox.styl
+++ b/stylesheets/components/form/_textbox.styl
@@ -25,7 +25,7 @@
     margin: 0 0 $sizing-300
 
   &-f
-    field-height = "calc(%srem + %s * 2)" % ($line-height-600 $border-200)
+    field-height = "calc(%srem + %s * 1)" % ($line-height-600 $border-200)
 
     font-family: $serif
     font-size: 1rem

--- a/stylesheets/components/form/_textbox.styl
+++ b/stylesheets/components/form/_textbox.styl
@@ -52,7 +52,7 @@
       border-color: $focus-indicator-color
 
     &--sm
-      field-height-sm = "calc(%srem + %s * 2)" % ($line-height-400 $border-200)
+      field-height-sm = "calc(%srem + %s * 1)" % ($line-height-400 $border-200)
 
       padding-left: $sizing-200
       padding-right: $sizing-200
@@ -74,7 +74,7 @@
     textarea&
       &.txt-f--combo
         // Need to leave space for a .sel-f--sq element, and its borders
-        width: "calc(100% - %s - %s * 2)" % ($select-arrow-box-width $border-200)
+        width: "calc(100% - %s - %s * 1)" % ($select-arrow-box-width $border-200)
 
     input[type=email]&--auto,
     input[type=tel]&--auto,


### PR DESCRIPTION
Tickets

- [ ] [DIG-4375](https://bostondoit.atlassian.net/browse/DIG-4059): Navigation Bar and Next Button behavior is aligned
-- Added/Updated `Modal` component
- [ ] [DIG-4375](https://bostondoit.atlassian.net/browse/DIG-4375): UX updates for Marriage Intention form
-- fix text getting cutoff at bottom on inputs in `Windows`

[DIG-4375]: https://bostondoit.atlassian.net/browse/DIG-4375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DIG-4375]: https://bostondoit.atlassian.net/browse/DIG-4375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ